### PR TITLE
change map_location to cpu to avoid OOM

### DIFF
--- a/src/fastwam/models/wan22/fastwam.py
+++ b/src/fastwam/models/wan22/fastwam.py
@@ -1098,7 +1098,7 @@ class FastWAM(torch.nn.Module):
         torch.save(payload, path)
 
     def load_checkpoint(self, path, optimizer=None):
-        payload = torch.load(path, map_location=self.device)
+        payload = torch.load(path, map_location="cpu")
         if "mot" in payload:
             self.mot.load_state_dict(payload["mot"], strict=False)
         elif "dit" in payload:

--- a/src/fastwam/models/wan22/helpers/loader.py
+++ b/src/fastwam/models/wan22/helpers/loader.py
@@ -113,7 +113,7 @@ def _load_registered_model(
     state_dict_converter = matched_config.get("state_dict_converter")
 
     model = model_class(**model_kwargs)
-    state_dict = load_state_dict(path, torch_dtype=torch_dtype, device=device)
+    state_dict = load_state_dict(path, torch_dtype=torch_dtype, device="cpu")
     if state_dict_converter is not None:
         state_dict = state_dict_converter(state_dict)
 

--- a/src/fastwam/models/wan22/wan22.py
+++ b/src/fastwam/models/wan22/wan22.py
@@ -395,7 +395,7 @@ class Wan22Core(torch.nn.Module):
         torch.save(payload, path)
 
     def load_checkpoint(self, path, optimizer=None):
-        payload = torch.load(path, map_location=self.device)
+        payload = torch.load(path, map_location="cpu")
         self.dit.load_state_dict(payload["dit"], strict=False)
         if optimizer is not None and "optimizer" in payload:
             optimizer.load_state_dict(payload["optimizer"])


### PR DESCRIPTION
## Summary
This PR fixes a bug reported in https://github.com/yuantianyuan01/FastWAM/issues/18: startup GPU memory was unexpectedly high right after model load.
The root cause was loading large checkpoints/state_dicts directly onto CUDA, which created temporary GPU tensors and inflated `reserved` memory in the CUDA caching allocator.

## Changes
- `src/fastwam/models/wan22/fastwam.py`
  - `FastWAM.load_checkpoint`: `map_location="cpu"` (was `self.device`)
- `src/fastwam/models/wan22/wan22.py`
  - `Wan22Core.load_checkpoint`: `map_location="cpu"` (was `self.device`)
- `src/fastwam/models/wan22/helpers/loader.py`
  - `_load_registered_model`: load pretrained `state_dict` on CPU (was loading on target device)

## Why
Loading large checkpoints directly on CUDA creates temporary GPU tensors that inflate `reserved` memory (CUDA caching allocator), making startup memory much higher than steady-state usage.