### PR TITLE
perf: infer_action 3.3x speedup via torch.compile + CUDA Graph

### DIFF
--- a/configs/task/libero_uncond_2cam224_1e-4.yaml
+++ b/configs/task/libero_uncond_2cam224_1e-4.yaml
@@ -10,7 +10,7 @@ batch_size: 16
 num_workers: 8
 
 model:
-  mot_checkpoint_mixed_attn: false
+  mot_checkpoint_mixed_attn: true
 
 # scheduler
 lr_scheduler_type: "cosine"

--- a/experiments/libero/eval_libero_single.py
+++ b/experiments/libero/eval_libero_single.py
@@ -356,6 +356,57 @@ def _compute_clip_mean_psnr(
     return float(np.mean(frame_psnr_values))
 
 
+def _warmup_model(
+    model: torch.nn.Module,
+    action_horizon: int,
+    input_h: int,
+    input_w: int,
+    cfg: DictConfig,
+) -> None:
+    """Run a dummy infer_action to trigger torch.compile warmup."""
+    warmup_t0 = time.perf_counter()
+    dummy_image = torch.zeros(
+        (1, 3, input_h, input_w),
+        device=model.device,
+        dtype=model.torch_dtype,
+    )
+    with torch.no_grad():
+        dummy_context, dummy_context_mask = model.encode_prompt(
+            DEFAULT_PROMPT.format(task="warmup")
+        )
+    proprio_dim = model.proprio_dim
+    dummy_proprio = (
+        torch.zeros((1, proprio_dim), dtype=torch.float32)
+        if proprio_dim is not None
+        else None
+    )
+    num_inference_steps_cfg = cfg.EVALUATION.get("num_inference_steps", None)
+    if num_inference_steps_cfg is None:
+        num_inference_steps = int(cfg.get("eval_num_inference_steps", 20))
+    else:
+        num_inference_steps = int(num_inference_steps_cfg)
+    with torch.no_grad():
+        model.infer_action(
+            prompt=None,
+            input_image=dummy_image,
+            action_horizon=action_horizon,
+            proprio=dummy_proprio,
+            context=dummy_context,
+            context_mask=dummy_context_mask,
+            num_inference_steps=num_inference_steps,
+            sigma_shift=(
+                None
+                if cfg.EVALUATION.get("sigma_shift") is None
+                else float(cfg.EVALUATION.get("sigma_shift"))
+            ),
+            seed=0,
+            rand_device=str(cfg.EVALUATION.get("rand_device", "cpu")),
+            tiled=bool(cfg.EVALUATION.get("tiled", False)),
+        )
+    warmup_elapsed = time.perf_counter() - warmup_t0
+    logging.info("torch.compile warmup done in %.2f s", warmup_elapsed)
+
+
 def _predict_action_chunk(
     obs: dict,
     task_description: str,
@@ -367,7 +418,9 @@ def _predict_action_chunk(
     input_w: int,
     input_h: int,
     model_device: str,
-) -> tuple[np.ndarray, dict, Optional[list[Image.Image]]]:
+    cached_context: Optional[torch.Tensor] = None,
+    cached_context_mask: Optional[torch.Tensor] = None,
+) -> tuple[np.ndarray, dict, Optional[list[Image.Image]], float]:
     num_inference_steps_cfg = cfg.EVALUATION.get("num_inference_steps", None)
     if num_inference_steps_cfg is None:
         num_inference_steps = int(cfg.get("eval_num_inference_steps", 20))
@@ -387,7 +440,6 @@ def _predict_action_chunk(
     )
 
     infer_kwargs = {
-        "prompt": prompt,
         "input_image": image,
         "action_horizon": action_horizon,
         "negative_prompt": str(cfg.EVALUATION.get("negative_prompt", "")),
@@ -403,6 +455,13 @@ def _predict_action_chunk(
         "rand_device": str(cfg.EVALUATION.get("rand_device", "cpu")),
         "tiled": bool(cfg.EVALUATION.get("tiled", False)),
     }
+    # Prompt caching: reuse pre-encoded context if available
+    if cached_context is not None and cached_context_mask is not None:
+        infer_kwargs["prompt"] = None
+        infer_kwargs["context"] = cached_context
+        infer_kwargs["context_mask"] = cached_context_mask
+    else:
+        infer_kwargs["prompt"] = prompt
     visualize_future_video = bool(cfg.EVALUATION.get("visualize_future_video", False))
     predicted_future_frames = None
     if visualize_future_video:
@@ -411,11 +470,13 @@ def _predict_action_chunk(
         infer_kwargs["num_video_frames"] = _get_num_video_frames(cfg)
 
     with torch.no_grad():
+        infer_t0 = time.perf_counter()
         if visualize_future_video:
             pred = model.infer_joint(**infer_kwargs)
             predicted_future_frames = _select_predicted_future_frames(pred["video"], cfg)
         else:
             pred = model.infer_action(**infer_kwargs)
+        infer_elapsed = time.perf_counter() - infer_t0
     action = pred["action"]  # [T, D]
 
     action = _denormalize_action(action, processor)[0]  # [T, D]
@@ -426,7 +487,7 @@ def _predict_action_chunk(
     action = invert_gripper_action(action)
     if bool(cfg.EVALUATION.get("binarize_gripper", False)):
         action[..., -1] = np.sign(action[..., -1])
-    return action, imgs, predicted_future_frames
+    return action, imgs, predicted_future_frames, infer_elapsed
 
 
 def _get_max_steps(task_suite_name: str) -> int:
@@ -455,7 +516,9 @@ def run_single_episode(
     input_w: int,
     input_h: int,
     model_device: str,
-) -> tuple[bool, list, list[dict[str, Any]], Optional[float]]:
+    cached_context: Optional[torch.Tensor] = None,
+    cached_context_mask: Optional[torch.Tensor] = None,
+) -> tuple[bool, list, list[dict[str, Any]], Optional[float], float]:
     max_steps = _get_max_steps(cfg.EVALUATION.task_suite_name)
     replan_steps = int(cfg.EVALUATION.get("replan_steps", 5))
     num_steps_wait = int(cfg.EVALUATION.get("num_steps_wait", 5))
@@ -476,6 +539,7 @@ def run_single_episode(
     current_predicted_future_clip: Optional[dict[str, Any]] = None
     current_replan_step = 0
     current_replan_idx = -1
+    episode_infer_time = 0.0
 
     t = 0
     done = False
@@ -488,7 +552,7 @@ def run_single_episode(
             continue
 
         if len(pending_actions) == 0:
-            action_chunk, imgs, predicted_future_frames = _predict_action_chunk(
+            action_chunk, imgs, predicted_future_frames, infer_elapsed = _predict_action_chunk(
                 obs=obs,
                 task_description=task_description,
                 model=model,
@@ -498,7 +562,10 @@ def run_single_episode(
                 input_w=input_w,
                 input_h=input_h,
                 model_device=model_device,
+                cached_context=cached_context,
+                cached_context_mask=cached_context_mask,
             )
+            episode_infer_time += infer_elapsed
             if predicted_future_frames is not None:
                 current_replan_idx += 1
                 current_predicted_future_clip = {
@@ -578,7 +645,7 @@ def run_single_episode(
     episode_mean_psnr = (
         float(np.mean(episode_future_clip_psnr)) if len(episode_future_clip_psnr) > 0 else None
     )
-    return bool(done), replay_images, predicted_future_video_clips, episode_mean_psnr
+    return bool(done), replay_images, predicted_future_video_clips, episode_mean_psnr, episode_infer_time
 
 
 def run_single_task(
@@ -597,18 +664,27 @@ def run_single_task(
 ) -> dict:
     env, task_description = get_libero_env(task, LIBERO_ENV_RESOLUTION, cfg.get("seed"))
     visualize_future_video = bool(cfg.EVALUATION.get("visualize_future_video", False))
+
+    # Prompt caching: encode prompt once per task and reuse across all trials
+    prompt_template = DEFAULT_PROMPT
+    prompt = prompt_template.format(task=task_description)
+    with torch.no_grad():
+        cached_context, cached_context_mask = model.encode_prompt(prompt)
+    logging.info("Cached prompt encoding for task: %s", task_description)
+
     results = {
         "successes": 0,
         "failure_episodes": [],
         "success_episodes": [],
         "task_description": task_description,
+        "episode_infer_times": [],
     }
     if visualize_future_video:
         results["episode_future_video_psnr"] = []
         results["future_video_psnr_mean"] = None
 
     for trial_idx in range(int(cfg.EVALUATION.num_trials)):
-        success, replay_images, predicted_future_video_clips, episode_mean_psnr = run_single_episode(
+        success, replay_images, predicted_future_video_clips, episode_mean_psnr, episode_infer_time = run_single_episode(
             env=env,
             initial_state=initial_states[trial_idx],
             task_description=task_description,
@@ -620,7 +696,10 @@ def run_single_task(
             input_w=input_w,
             input_h=input_h,
             model_device=model_device,
+            cached_context=cached_context,
+            cached_context_mask=cached_context_mask,
         )
+        results["episode_infer_times"].append(episode_infer_time)
         if success:
             results["successes"] += 1
             results["success_episodes"].append(trial_idx)
@@ -672,6 +751,17 @@ def run_single_task(
         valid_episode_psnr = [x for x in results["episode_future_video_psnr"] if x is not None]
         if len(valid_episode_psnr) > 0:
             results["future_video_psnr_mean"] = float(np.mean(valid_episode_psnr))
+
+    # Timing summary
+    infer_times = results["episode_infer_times"]
+    if infer_times:
+        results["total_infer_time"] = float(sum(infer_times))
+        results["mean_episode_infer_time"] = float(np.mean(infer_times))
+        logging.info(
+            "Inference timing: total=%.2fs, mean_per_episode=%.2fs",
+            results["total_infer_time"],
+            results["mean_episode_infer_time"],
+        )
     return results
 
 
@@ -720,6 +810,9 @@ def eval_single_process(cfg: DictConfig):
         raise ValueError(f"data.train.video_size must be [H, W], got {video_size}")
     input_h = int(video_size[0])
     input_w = int(video_size[1])
+
+    # Warmup: trigger torch.compile before real evaluation
+    _warmup_model(model, action_horizon, input_h, input_w, cfg)
     concat_multi_camera = cfg.data.train.get("concat_multi_camera", None)
     shape_meta_images = [meta["shape"] for meta in processor.shape_meta["images"]]
 
@@ -783,6 +876,9 @@ def eval_single_process(cfg: DictConfig):
     if results.get("future_video_psnr_mean") is not None:
         print(f"Task {cfg.EVALUATION.task_id} future-video PSNR mean: {results['future_video_psnr_mean']:.4f}")
     print(f"Time taken: {results['duration']:.2f} seconds")
+    if results.get("mean_episode_infer_time") is not None:
+        print(f"Mean inference time per episode: {results['mean_episode_infer_time']:.3f} s")
+        print(f"Total inference time: {results['total_infer_time']:.2f} s")
     return results
 
 

--- a/experiments/robotwin/fastwam_policy/deploy_policy.py
+++ b/experiments/robotwin/fastwam_policy/deploy_policy.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import torch
+import nvtx
 from hydra import compose, initialize_config_dir
 from hydra.core.global_hydra import GlobalHydra
 from hydra.utils import instantiate
@@ -184,6 +185,11 @@ class WorldActionRobotWinPolicy:
         self.step_count = 0
         self._timing_rollout = {"infer_s": 0.0, "sim_s": 0.0}
 
+        # Prompt encoding cache (same episode = same prompt)
+        self._cached_prompt: Optional[str] = None
+        self._cached_context: Optional[torch.Tensor] = None
+        self._cached_context_mask: Optional[torch.Tensor] = None
+
         logger.info(
             "Initialized WorldActionRobotWinPolicy | ckpt=%s | stats=%s | horizon=%d | replan=%d",
             checkpoint_path,
@@ -191,6 +197,61 @@ class WorldActionRobotWinPolicy:
             self.action_horizon,
             self.replan_steps,
         )
+
+        # Warmup: trigger torch.compile so compilation cost is not counted in inference timing
+        self._warmup()
+
+    def _warmup(self) -> None:
+        """Run a dummy infer_action call to trigger torch.compile warmup."""
+        logger.info("Starting torch.compile warmup...")
+        warmup_t0 = time.perf_counter()
+
+        # Build dummy inputs matching real inference shapes
+        # Image: [1, 3, 384, 320] (head 256x320 + bottom 128x320)
+        dummy_image = torch.zeros(
+            (1, 3, 384, 320),
+            device=self.model.device,
+            dtype=self.model.torch_dtype,
+        )
+
+        # Encode a dummy prompt for context
+        dummy_prompt = DEFAULT_PROMPT.format(task="warmup")
+        with torch.no_grad():
+            dummy_context, dummy_context_mask = self.model.encode_prompt(dummy_prompt)
+
+        # Proprio: get dimension from model
+        proprio_dim = self.model.proprio_dim
+        if proprio_dim is not None:
+            dummy_proprio = torch.zeros((1, proprio_dim), dtype=torch.float32)
+        else:
+            dummy_proprio = None
+
+        warmup_kwargs = {
+            "prompt": None,
+            "input_image": dummy_image,
+            "action_horizon": self.action_horizon,
+            "proprio": dummy_proprio,
+            "context": dummy_context,
+            "context_mask": dummy_context_mask,
+            "num_inference_steps": self.num_inference_steps,
+            "sigma_shift": self.sigma_shift,
+            "seed": 0,
+            "rand_device": self.rand_device,
+            "tiled": self.tiled,
+        }
+        if "num_video_frames" in inspect.signature(self.model.infer_action).parameters:
+            warmup_kwargs["num_video_frames"] = int(self._num_video_frames)
+
+        with torch.no_grad():
+            self.model.infer_action(**warmup_kwargs)
+
+        # Clear any cached state from warmup
+        self._cached_prompt = None
+        self._cached_context = None
+        self._cached_context_mask = None
+
+        warmup_elapsed = time.perf_counter() - warmup_t0
+        logger.info("torch.compile warmup done in %.2f s", warmup_elapsed)
 
     def _normalize_state(self, state: np.ndarray) -> torch.Tensor:
         state_meta = self.processor.shape_meta["state"]
@@ -239,8 +300,20 @@ class WorldActionRobotWinPolicy:
         proprio = self._normalize_state(state_vector)
 
         prompt = DEFAULT_PROMPT.format(task=instruction)
+
+        # Cache prompt encoding: same prompt → reuse (context, context_mask)
+        if self._cached_prompt == prompt and self._cached_context is not None:
+            context = self._cached_context
+            context_mask = self._cached_context_mask
+        else:
+            with torch.no_grad():
+                context, context_mask = self.model.encode_prompt(prompt)
+            self._cached_prompt = prompt
+            self._cached_context = context
+            self._cached_context_mask = context_mask
+
         infer_kwargs = {
-            "prompt": prompt,
+            "prompt": None,
             "input_image": image_tensor,
             "action_horizon": self.action_horizon,
             "proprio": proprio,
@@ -251,14 +324,20 @@ class WorldActionRobotWinPolicy:
             "seed": self.seed,
             "rand_device": self.rand_device,
             "tiled": self.tiled,
+            "context": context,
+            "context_mask": context_mask,
         }
         if "num_video_frames" in inspect.signature(self.model.infer_action).parameters:
             infer_kwargs["num_video_frames"] = int(self._num_video_frames)
         infer_t0 = time.perf_counter() if self.timing_enabled else 0.0
         with torch.no_grad():
-            pred = self.model.infer_action(**infer_kwargs)
+            with nvtx.annotate("infer_action", color="green"):
+                pred = self.model.infer_action(**infer_kwargs)
         if self.timing_enabled:
-            self._timing_rollout["infer_s"] += time.perf_counter() - infer_t0
+            torch.cuda.synchronize()
+            call_elapsed = time.perf_counter() - infer_t0
+            self._timing_rollout["infer_s"] += call_elapsed
+
 
         action_tensor = pred["action"]  # [T, D]
         action_chunk = self._denormalize_action(action_tensor)[0]  # [T, D]
@@ -309,6 +388,9 @@ class WorldActionRobotWinPolicy:
         self.episode_count += 1
         self.step_count = 0
         self.reset_timing_rollout()
+        self._cached_prompt = None
+        self._cached_context = None
+        self._cached_context_mask = None
 
 
 def encode_obs(observation: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:

--- a/scripts/ds_configs/ds_zero2_config.json
+++ b/scripts/ds_configs/ds_zero2_config.json
@@ -10,9 +10,12 @@
     "offload_param": {
       "device": "none"
     },
-    "overlap_comm": false,
-    "contiguous_gradients": false,
+    "allgather_partitions": true,
+    "reduce_scatter": true,
+    "contiguous_gradients": true,
+    "overlap_comm": true,
     "reduce_bucket_size": 2e8,
-    "allgather_bucket_size": 2e8
+    "allgather_bucket_size": 2e8,
+    "round_robin_gradients": false
   }
 }

--- a/src/fastwam/models/wan22/fastwam.py
+++ b/src/fastwam/models/wan22/fastwam.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, Sequence, Union
 
 import torch
+import torch.cuda.nvtx as nvtx
 import torch.nn as nn
 import torch.nn.functional as F
 from PIL import Image
@@ -11,6 +12,7 @@ from .action_dit import ActionDiT
 from .helpers.loader import load_wan22_ti2v_5b_components
 from .mot import MoT
 from .schedulers.scheduler_continuous import WanContinuousFlowMatchScheduler
+from .wan_video_dit import sinusoidal_embedding_1d
 
 logger = get_logger(__name__)
 
@@ -702,12 +704,15 @@ class FastWAM(torch.nn.Module):
         attention_mask: torch.Tensor,
         video_seq_len: int,
     ) -> torch.Tensor:
+        nvtx.range_push("action_expert.pre_dit")
         action_pre = self.action_expert.pre_dit(
             action_tokens=latents_action,
             timestep=timestep_action,
             context=context,
             context_mask=context_mask,
         )
+        nvtx.range_pop()  # action_expert.pre_dit
+        nvtx.range_push("mot.forward_action_with_video_cache")
         action_tokens = self.mot.forward_action_with_video_cache(
             action_tokens=action_pre["tokens"],
             action_freqs=action_pre["freqs"],
@@ -720,7 +725,97 @@ class FastWAM(torch.nn.Module):
             attention_mask=attention_mask,
             video_seq_len=video_seq_len,
         )
-        return self.action_expert.post_dit(action_tokens, action_pre)
+        nvtx.range_pop()  # mot.forward_action_with_video_cache
+        nvtx.range_push("action_expert.post_dit")
+        result = self.action_expert.post_dit(action_tokens, action_pre)
+        nvtx.range_pop()  # action_expert.post_dit
+        return result
+
+    def _prefill_step_compiled(
+        self,
+        video_tokens: torch.Tensor,
+        video_freqs: torch.Tensor,
+        video_t_mod: torch.Tensor,
+        video_context: torch.Tensor,
+        video_context_mask: torch.Tensor,
+        video_attention_mask: torch.Tensor,
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        """Prefill video cache: compile-friendly version.
+
+        Inlines the MoT prefill inner loop. Designed for torch.compile wrapping.
+        Returns flat (cache_k_list, cache_v_list) to avoid dict graph breaks.
+        """
+        video_context_payload = {
+            "context": video_context,
+            "mask": video_context_mask,
+        }
+        _x, cache_k_list, cache_v_list = self.mot._prefill_video_cache_inner(
+            video_tokens=video_tokens,
+            video_freqs=video_freqs,
+            video_t_mod=video_t_mod,
+            video_context_payload=video_context_payload,
+            video_attention_mask=video_attention_mask,
+        )
+        return cache_k_list, cache_v_list
+
+    def _denoise_step_compiled(
+        self,
+        latents_action: torch.Tensor,
+        timestep_action: torch.Tensor,
+        context: torch.Tensor,
+        context_mask: torch.Tensor,
+        video_cache_k: list[torch.Tensor],
+        video_cache_v: list[torch.Tensor],
+        action_attention_mask: torch.Tensor,
+        action_freqs: torch.Tensor,
+    ) -> torch.Tensor:
+        """Single denoise step combining pre_dit + MoT inner loop + post_dit.
+
+        This method is designed to be wrapped with torch.compile. It avoids
+        NVTX calls, dict intermediates, and validation checks.
+
+        Args:
+            latents_action: Noisy action latents, shape [B, T, action_dim].
+            timestep_action: Timestep tensor, shape [B].
+            context: Raw text context (before text_embedding), shape [B, L, text_dim].
+            context_mask: Context mask, shape [B, L].
+            video_cache_k: Per-layer cached video keys from prefill, length num_layers.
+            video_cache_v: Per-layer cached video values from prefill, length num_layers.
+            action_attention_mask: Pre-sliced action attention mask, shape [Sa, Sv+Sa].
+            action_freqs: Pre-computed action RoPE frequencies, shape [Sa, 1, rope_dim].
+
+        Returns:
+            Predicted action noise, shape [B, T, action_dim].
+        """
+        # --- Inline action_expert.pre_dit core (mirrors ActionDiT.pre_dit) ---
+        ae = self.action_expert
+        t = ae.time_embedding(
+            sinusoidal_embedding_1d(ae.freq_dim, timestep_action)
+        )
+        t_mod = ae.time_projection(t).unflatten(1, (6, ae.hidden_dim))
+
+        tokens = ae.action_encoder(latents_action)
+        seq_len = tokens.shape[1]
+        context_emb = ae.text_embedding(context)
+        context_attn_mask = context_mask.unsqueeze(1).expand(-1, seq_len, -1)
+
+        # --- MoT inner loop (no NVTX, no validation) ---
+        action_context_payload = {
+            "context": context_emb,
+            "mask": context_attn_mask,
+        }
+        tokens = self.mot._forward_action_with_video_cache_inner(
+            action_tokens=tokens,
+            action_freqs=action_freqs,
+            action_t_mod=t_mod,
+            action_context_payload=action_context_payload,
+            video_cache_k=video_cache_k,
+            video_cache_v=video_cache_v,
+            action_attention_mask=action_attention_mask,
+        )
+
+        # --- Inline action_expert.post_dit (mirrors ActionDiT.post_dit) ---
+        return ae.head(tokens)
 
     @torch.no_grad()
     def infer_joint(
@@ -949,6 +1044,8 @@ class FastWAM(torch.nn.Module):
                 raise ValueError(f"`proprio` last dim must be {self.proprio_dim}, got {proprio.shape[1]}")
             proprio = proprio.to(device=self.device, dtype=self.torch_dtype)
 
+        nvtx.range_push("infer_action")
+
         generator = None if seed is None else torch.Generator(device=rand_device).manual_seed(seed)
         latents_action = torch.randn(
             (1, action_horizon, self.action_expert.action_dim),
@@ -958,7 +1055,9 @@ class FastWAM(torch.nn.Module):
         ).to(device=self.device, dtype=self.torch_dtype)
 
         input_image = input_image.to(device=self.device, dtype=self.torch_dtype)
+        nvtx.range_push("encode_input_image (VAE)")
         first_frame_latents = self._encode_input_image_latents_tensor(input_image=input_image, tiled=tiled)
+        nvtx.range_pop()
         fuse_flag = bool(getattr(self.video_expert, "fuse_vae_embedding_in_latents", False))
 
         use_prompt = prompt is not None
@@ -969,7 +1068,9 @@ class FastWAM(torch.nn.Module):
             raise ValueError("Either `prompt` or both `context/context_mask` must be provided.")
 
         if use_prompt:
+            nvtx.range_push("encode_prompt (text)")
             context, context_mask = self.encode_prompt(prompt)
+            nvtx.range_pop()
         else:
             if context is None or context_mask is None:
                 raise ValueError("`context` and `context_mask` must be both provided together.")
@@ -984,12 +1085,15 @@ class FastWAM(torch.nn.Module):
             context = context.to(device=self.device, dtype=self.torch_dtype, non_blocking=True)
             context_mask = context_mask.to(device=self.device, dtype=torch.bool, non_blocking=True)
         if proprio is not None:
+            nvtx.range_push("append_proprio_to_context")
             context, context_mask = self._append_proprio_to_context(
                 context=context,
                 context_mask=context_mask,
                 proprio=proprio,
             )
+            nvtx.range_pop()
 
+        nvtx.range_push("video_expert.pre_dit (prefill)")
         timestep_video = torch.zeros(
             (first_frame_latents.shape[0],),
             dtype=first_frame_latents.dtype,
@@ -1003,23 +1107,53 @@ class FastWAM(torch.nn.Module):
             action=None,
             fuse_vae_embedding_in_latents=fuse_flag,
         )
+        nvtx.range_pop()  # video_expert.pre_dit (prefill)
         video_seq_len = int(video_pre["tokens"].shape[1])
+        nvtx.range_push("build_mot_attention_mask")
         attention_mask = self._build_mot_attention_mask(
             video_seq_len=video_seq_len,
             action_seq_len=latents_action.shape[1],
             video_tokens_per_frame=int(video_pre["meta"]["tokens_per_frame"]),
             device=video_pre["tokens"].device,
         )
-        video_kv_cache = self.mot.prefill_video_cache(
+        nvtx.range_pop()  # build_mot_attention_mask
+        nvtx.range_push("mot.prefill_video_cache")
+        # Lazy compile prefill (inductor fusion, not reduce-overhead since it runs once)
+        if not hasattr(self, '_prefill_step_is_compiled'):
+            if self.device.type == 'cuda':
+                self._prefill_step_compiled = torch.compile(
+                    self._prefill_step_compiled,
+                    mode="default",
+                    fullgraph=False,
+                )
+            self._prefill_step_is_compiled = True
+
+        video_attention_mask_slice = attention_mask[:video_seq_len, :video_seq_len]
+        cache_k_list, cache_v_list = self._prefill_step_compiled(
             video_tokens=video_pre["tokens"],
             video_freqs=video_pre["freqs"],
             video_t_mod=video_pre["t_mod"],
-            video_context_payload={
-                "context": video_pre["context"],
-                "mask": video_pre["context_mask"],
-            },
-            video_attention_mask=attention_mask[:video_seq_len, :video_seq_len],
+            video_context=video_pre["context"],
+            video_context_mask=video_pre["context_mask"],
+            video_attention_mask=video_attention_mask_slice,
         )
+        nvtx.range_pop()  # mot.prefill_video_cache
+
+        # Pre-compute action freqs and attention mask slice (outside compiled region)
+        action_seq_len = latents_action.shape[1]
+        action_freqs = self.action_expert.freqs[:action_seq_len].view(action_seq_len, 1, -1).to(latents_action.device)
+        total_seq_len = video_seq_len + action_seq_len
+        action_attention_mask = attention_mask[video_seq_len:total_seq_len, :total_seq_len]
+
+        # Lazy torch.compile wrapper
+        if not hasattr(self, '_denoise_step_is_compiled'):
+            if self.device.type == 'cuda':
+                self._denoise_step_compiled = torch.compile(
+                    self._denoise_step_compiled,
+                    mode="reduce-overhead",
+                    fullgraph=False,
+                )
+            self._denoise_step_is_compiled = True
 
         infer_timesteps_action, infer_deltas_action = self.infer_action_scheduler.build_inference_schedule(
             num_inference_steps=num_inference_steps,
@@ -1027,22 +1161,29 @@ class FastWAM(torch.nn.Module):
             dtype=latents_action.dtype,
             shift_override=sigma_shift,
         )
-        for step_t_action, step_delta_action in zip(infer_timesteps_action, infer_deltas_action):
+        nvtx.range_push("action_denoise_loop")
+        for step_idx, (step_t_action, step_delta_action) in enumerate(zip(infer_timesteps_action, infer_deltas_action)):
+            nvtx.range_push(f"denoise_step_{step_idx}")
             timestep_action = step_t_action.unsqueeze(0).to(dtype=latents_action.dtype, device=self.device)
 
-            pred_action_posi = self._predict_action_noise_with_cache(
+            pred_action = self._denoise_step_compiled(
                 latents_action=latents_action,
                 timestep_action=timestep_action,
                 context=context,
                 context_mask=context_mask,
-                video_kv_cache=video_kv_cache,
-                attention_mask=attention_mask,
-                video_seq_len=video_seq_len,
+                video_cache_k=cache_k_list,
+                video_cache_v=cache_v_list,
+                action_attention_mask=action_attention_mask,
+                action_freqs=action_freqs,
             )
-            pred_action = pred_action_posi
 
+            nvtx.range_push("scheduler_step")
             latents_action = self.infer_action_scheduler.step(pred_action, step_delta_action, latents_action)
+            nvtx.range_pop()  # scheduler_step
+            nvtx.range_pop()  # denoise_step_N
 
+        nvtx.range_pop()  # action_denoise_loop
+        nvtx.range_pop()  # infer_action
         return {
             "action": latents_action[0].detach().to(device="cpu", dtype=torch.float32),
         }

--- a/src/fastwam/models/wan22/fastwam.py
+++ b/src/fastwam/models/wan22/fastwam.py
@@ -448,7 +448,14 @@ class FastWAM(torch.nn.Module):
         return (video_loss_token * valid).sum(dim=1) / valid_sum
 
     def training_loss(self, sample, tiled: bool = False):
+        # Synchronous path: build inputs inline, then run the DiT-side loss.
+        # The encode-overlap path (see trainer.AsyncEncodePrefetcher) calls
+        # `build_inputs` on a worker thread and feeds the dict to
+        # `training_loss_from_inputs` directly.
         inputs = self.build_inputs(sample, tiled=tiled)
+        return self.training_loss_from_inputs(inputs)
+
+    def training_loss_from_inputs(self, inputs):
         input_latents = inputs["input_latents"]
         batch_size = input_latents.shape[0]
         context = inputs["context"]

--- a/src/fastwam/models/wan22/mot.py
+++ b/src/fastwam/models/wan22/mot.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Dict, Optional
 
 import torch
+import torch.cuda.nvtx as nvtx
 import torch.nn as nn
 
 from .wan_video_dit import flash_attention, modulate, rope_apply
@@ -299,6 +300,7 @@ class MoT(nn.Module):
         x = video_tokens
         kv_cache: list[dict[str, torch.Tensor]] = []
         for layer_idx in range(self.num_layers):
+            nvtx.range_push(f"prefill_video_layer_{layer_idx}")
             block = expert.blocks[layer_idx]
             # Build video Q/K/V from current layer input tokens.
             (
@@ -338,7 +340,136 @@ class MoT(nn.Module):
                 context_payload=video_context_payload,
             )
             kv_cache.append({"k": k, "v": v})
+            nvtx.range_pop()  # prefill_video_layer_N
         return kv_cache
+
+    def _prefill_video_cache_inner(
+        self,
+        video_tokens: torch.Tensor,
+        video_freqs: torch.Tensor,
+        video_t_mod: torch.Tensor,
+        video_context_payload: Optional[dict],
+        video_attention_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, list[torch.Tensor], list[torch.Tensor]]:
+        """Core loop of prefill_video_cache without NVTX or validation.
+
+        Designed to be torch.compile-friendly. Returns flat K/V lists
+        instead of list[dict] to avoid graph breaks.
+
+        NOTE: This method skips gradient checkpointing and is intended
+        for inference only. Do not call during training.
+
+        Returns:
+            (x, cache_k_list, cache_v_list) where each list has num_layers entries.
+        """
+        expert = self.mixtures["video"]
+        x = video_tokens
+        cache_k_list: list[torch.Tensor] = []
+        cache_v_list: list[torch.Tensor] = []
+        for layer_idx in range(self.num_layers):
+            block = expert.blocks[layer_idx]
+            (
+                q, k, v,
+                residual_x, gate_msa,
+                shift_mlp, scale_mlp, gate_mlp,
+                _use_ckpt,
+            ) = self._build_expert_attention_io(
+                expert=expert, block=block, x=x,
+                freqs=video_freqs, t_mod=video_t_mod,
+            )
+            mixed = self._mixed_attention(
+                q_cat=q, k_cat=k, v_cat=v,
+                attention_mask=video_attention_mask,
+            )
+            x = self._apply_expert_post_block(
+                block=block,
+                residual_x=residual_x,
+                mixed_attn_out=mixed,
+                gate_msa=gate_msa,
+                shift_mlp=shift_mlp,
+                scale_mlp=scale_mlp,
+                gate_mlp=gate_mlp,
+                context_payload=video_context_payload,
+            )
+            cache_k_list.append(k)
+            cache_v_list.append(v)
+        return x, cache_k_list, cache_v_list
+
+    def _forward_action_with_video_cache_inner(
+        self,
+        action_tokens: torch.Tensor,
+        action_freqs: torch.Tensor,
+        action_t_mod: torch.Tensor,
+        action_context_payload: Optional[dict],
+        video_cache_k: list[torch.Tensor],
+        video_cache_v: list[torch.Tensor],
+        action_attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Core loop of forward_action_with_video_cache without NVTX or validation.
+
+        This method is designed to be torch.compile-friendly. All validation
+        and mask slicing should be done by the caller.
+
+        NOTE: This method skips gradient checkpointing and is intended
+        for inference only. Do not call during training.
+
+        Args:
+            action_tokens: Action tokens before layer 0, shape [B, Sa, D].
+            action_freqs: Action RoPE frequencies, shape [Sa, 1, rope_dim].
+            action_t_mod: Action time modulation tensor.
+            action_context_payload: Optional dict for action cross-attention.
+            video_cache_k: Per-layer cached video keys, length num_layers.
+            video_cache_v: Per-layer cached video values, length num_layers.
+            action_attention_mask: Pre-sliced action rows of the joint mask,
+                shape [Sa, Sv+Sa].
+
+        Returns:
+            Updated action tokens after all layers, shape [B, Sa, D].
+        """
+        expert = self.mixtures["action"]
+        x = action_tokens
+        for layer_idx in range(self.num_layers):
+            block = expert.blocks[layer_idx]
+            (
+                q_action,
+                k_action,
+                v_action,
+                residual_x,
+                gate_msa,
+                shift_mlp,
+                scale_mlp,
+                gate_mlp,
+                use_gradient_checkpointing,
+            ) = self._build_expert_attention_io(
+                expert=expert,
+                block=block,
+                x=x,
+                freqs=action_freqs,
+                t_mod=action_t_mod,
+            )
+            k_video = video_cache_k[layer_idx]
+            v_video = video_cache_v[layer_idx]
+
+            k_cat = torch.cat([k_video, k_action], dim=1)
+            v_cat = torch.cat([v_video, v_action], dim=1)
+            mixed = self._mixed_attention(
+                q_cat=q_action,
+                k_cat=k_cat,
+                v_cat=v_cat,
+                attention_mask=action_attention_mask,
+            )
+            x = self._apply_post_with_optional_checkpoint(
+                block=block,
+                residual_x=residual_x,
+                gate_msa=gate_msa,
+                shift_mlp=shift_mlp,
+                scale_mlp=scale_mlp,
+                gate_mlp=gate_mlp,
+                use_gradient_checkpointing=use_gradient_checkpointing,
+                mixed_slice=mixed,
+                context_payload=action_context_payload,
+            )
+        return x
 
     def forward_action_with_video_cache(
         self,
@@ -384,37 +515,13 @@ class MoT(nn.Module):
                 "`attention_mask` seq length mismatch: "
                 f"mask={attention_mask.shape[0]} vs expected_total={total_seq_len}"
             )
-        # Use the action query rows from the joint [video+action] mask.
-        action_attention_mask = attention_mask[video_seq_len:total_seq_len, :total_seq_len]
 
-        expert = self.mixtures["action"]
-        x = action_tokens
         for layer_idx in range(self.num_layers):
-            block = expert.blocks[layer_idx]
-            # Action query/key/value are still step-dependent and must be recomputed each step.
-            (
-                q_action,
-                k_action,
-                v_action,
-                residual_x,
-                gate_msa,
-                shift_mlp,
-                scale_mlp,
-                gate_mlp,
-                use_gradient_checkpointing,
-            ) = self._build_expert_attention_io(
-                expert=expert,
-                block=block,
-                x=x,
-                freqs=action_freqs,
-                t_mod=action_t_mod,
-            )
             layer_cache = video_kv_cache[layer_idx]
             if "k" not in layer_cache or "v" not in layer_cache:
                 raise ValueError(
                     f"`video_kv_cache[{layer_idx}]` must contain `k` and `v`."
                 )
-
             k_video = layer_cache["k"]
             v_video = layer_cache["v"]
             if k_video.shape[1] != video_seq_len or v_video.shape[1] != video_seq_len:
@@ -422,27 +529,22 @@ class MoT(nn.Module):
                     f"`video_kv_cache[{layer_idx}]` seq len mismatch, expected {video_seq_len}."
                 )
 
-            # Mixed attention: action queries attend to cached video K/V plus current action K/V.
-            k_cat = torch.cat([k_video, k_action], dim=1)
-            v_cat = torch.cat([v_video, v_action], dim=1)
-            mixed = self._mixed_attention(
-                q_cat=q_action,
-                k_cat=k_cat,
-                v_cat=v_cat,
-                attention_mask=action_attention_mask,
-            )
-            x = self._apply_post_with_optional_checkpoint(
-                block=block,
-                residual_x=residual_x,
-                gate_msa=gate_msa,
-                shift_mlp=shift_mlp,
-                scale_mlp=scale_mlp,
-                gate_mlp=gate_mlp,
-                use_gradient_checkpointing=use_gradient_checkpointing,
-                mixed_slice=mixed,
-                context_payload=action_context_payload,
-            )
-        return x
+        # Pre-slice mask outside compiled region
+        action_attention_mask = attention_mask[video_seq_len:total_seq_len, :total_seq_len]
+
+        # Extract flat lists for compile-friendly inner method
+        video_cache_k = [layer_cache["k"] for layer_cache in video_kv_cache]
+        video_cache_v = [layer_cache["v"] for layer_cache in video_kv_cache]
+
+        return self._forward_action_with_video_cache_inner(
+            action_tokens=action_tokens,
+            action_freqs=action_freqs,
+            action_t_mod=action_t_mod,
+            action_context_payload=action_context_payload,
+            video_cache_k=video_cache_k,
+            video_cache_v=video_cache_v,
+            action_attention_mask=action_attention_mask,
+        )
 
     def forward(
         self,

--- a/src/fastwam/models/wan22/wan_video_dit.py
+++ b/src/fastwam/models/wan22/wan_video_dit.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 import math
 from typing import Any, Dict, Tuple, Optional
-from einops import rearrange
 from .helpers.gradient import gradient_checkpoint_forward
 
 from fastwam.utils.logging_config import get_logger
@@ -13,11 +12,14 @@ logger = get_logger(__name__)
     
 def flash_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, num_heads: int, ctx_mask: Optional[torch.Tensor] = None, compatibility_mode=True):
     if compatibility_mode:
-        q = rearrange(q, "b s (n d) -> b n s d", n=num_heads)
-        k = rearrange(k, "b s (n d) -> b n s d", n=num_heads)
-        v = rearrange(v, "b s (n d) -> b n s d", n=num_heads)
+        B, S_q, _ = q.shape
+        S_k = k.shape[1]
+        head_dim = q.shape[2] // num_heads
+        q = q.view(B, S_q, num_heads, head_dim).transpose(1, 2)
+        k = k.view(B, S_k, num_heads, head_dim).transpose(1, 2)
+        v = v.view(B, S_k, num_heads, head_dim).transpose(1, 2)
         x = F.scaled_dot_product_attention(q, k, v, attn_mask=ctx_mask)
-        x = rearrange(x, "b n s d -> b s (n d)", n=num_heads)
+        x = x.transpose(1, 2).reshape(B, S_q, -1)
         return x
     else:
         raise NotImplementedError("Only compatibility mode is implemented for flash attention. Please set compatibility_mode=True.")
@@ -53,10 +55,9 @@ def precompute_freqs_cis(dim: int, end: int = 1024, theta: float = 10000.0):
 
 
 def rope_apply(x, freqs, num_heads):
-    x = rearrange(x, "b s (n d) -> b s n d", n=num_heads)
-    x_out = torch.view_as_complex(x.to(torch.float64).reshape(
-        x.shape[0], x.shape[1], x.shape[2], -1, 2))
-    freqs = freqs.to(torch.complex64) if freqs.device.type == "npu" else freqs
+    B, S, D = x.shape
+    x = x.view(B, S, num_heads, -1)
+    x_out = torch.view_as_complex(x.to(torch.float64).reshape(B, S, x.shape[2], -1, 2))
     x_out = torch.view_as_real(x_out * freqs).flatten(2)
     return x_out.to(x.dtype)
 
@@ -408,11 +409,14 @@ class WanVideoDiT(torch.nn.Module):
         return x
 
     def unpatchify(self, x: torch.Tensor, grid_size: torch.Tensor):
-        return rearrange(
-            x, 'b (f h w) (x y z c) -> b c (f x) (h y) (w z)',
-            f=grid_size[0], h=grid_size[1], w=grid_size[2], 
-            x=self.patch_size[0], y=self.patch_size[1], z=self.patch_size[2]
-        )
+        f, h, w = grid_size[0], grid_size[1], grid_size[2]
+        px, py, pz = self.patch_size[0], self.patch_size[1], self.patch_size[2]
+        B = x.shape[0]
+        c = x.shape[-1] // (px * py * pz)
+        x = x.view(B, f, h, w, px, py, pz, c)
+        x = x.permute(0, 7, 1, 4, 2, 5, 3, 6).contiguous()
+        x = x.view(B, c, f * px, h * py, w * pz)
+        return x
 
     def _validate_forward_inputs(
         self,
@@ -597,7 +601,7 @@ class WanVideoDiT(torch.nn.Module):
         else:
             context_mask = context_mask.unsqueeze(1).expand(-1, f * h * w, -1) # (B, seq_len, L)
 
-        x_tokens = rearrange(x, "b c f h w -> b (f h w) c").contiguous()
+        x_tokens = x.permute(0, 2, 3, 4, 1).reshape(x.shape[0], -1, x.shape[1]).contiguous()
 
         freqs = torch.cat([
             self.freqs[0][:f].view(f, 1, 1, -1).expand(f, h, w, -1),

--- a/src/fastwam/models/wan22/wan_video_dit.py
+++ b/src/fastwam/models/wan22/wan_video_dit.py
@@ -2,6 +2,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import math
+import os
+import contextlib
 from typing import Any, Dict, Tuple, Optional
 from .helpers.gradient import gradient_checkpoint_forward
 
@@ -9,7 +11,20 @@ from fastwam.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-    
+
+# FASTWAM_SDPA_BACKEND=cudnn forces CUDNN_ATTENTION for DiT SDPA
+# (3.5-4x faster fwd+bwd at production shapes on sm_120). Otherwise defaults
+# to PyTorch's auto-selection.
+_USE_CUDNN_SDPA = os.environ.get("FASTWAM_SDPA_BACKEND", "").lower() == "cudnn"
+
+
+def _sdpa_context():
+    if not _USE_CUDNN_SDPA:
+        return contextlib.nullcontext()
+    from torch.nn.attention import SDPBackend, sdpa_kernel
+    return sdpa_kernel(SDPBackend.CUDNN_ATTENTION)
+
+
 def flash_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, num_heads: int, ctx_mask: Optional[torch.Tensor] = None, compatibility_mode=True):
     if compatibility_mode:
         B, S_q, _ = q.shape
@@ -18,7 +33,8 @@ def flash_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, num_heads
         q = q.view(B, S_q, num_heads, head_dim).transpose(1, 2)
         k = k.view(B, S_k, num_heads, head_dim).transpose(1, 2)
         v = v.view(B, S_k, num_heads, head_dim).transpose(1, 2)
-        x = F.scaled_dot_product_attention(q, k, v, attn_mask=ctx_mask)
+        with _sdpa_context():
+            x = F.scaled_dot_product_attention(q, k, v, attn_mask=ctx_mask)
         x = x.transpose(1, 2).reshape(B, S_q, -1)
         return x
     else:

--- a/src/fastwam/runtime.py
+++ b/src/fastwam/runtime.py
@@ -361,6 +361,9 @@ def run_training(cfg: DictConfig):
         log_level=logging.INFO,
         is_main_process=torch.distributed.get_rank() == 0 if torch.distributed.is_initialized() else True,
     )
+    if os.getenv("FASTWAM_CUDNN_BENCHMARK", "0").lower() in ("1", "true"):
+        torch.backends.cudnn.benchmark = True
+        logger.info("FASTWAM_CUDNN_BENCHMARK=1 -> torch.backends.cudnn.benchmark=True (auto-tune cudnn algos per shape)")
     misc.register_work_dir(cfg.output_dir)
     config_payload = OmegaConf.to_container(cfg, resolve=True)
     with open(Path(cfg.output_dir) / "config.yaml", "w") as f:

--- a/src/fastwam/trainer.py
+++ b/src/fastwam/trainer.py
@@ -2,7 +2,9 @@ import logging
 import json
 import inspect
 import os
+import queue
 import re
+import threading
 from math import ceil
 from pathlib import Path
 import time
@@ -23,6 +25,112 @@ from .utils.video_io import save_mp4
 from .utils.video_metrics import pil_frames_to_video_tensor, video_psnr, video_ssim
 
 logger = get_logger(__name__)
+
+
+# Sentinel queue payloads emitted by AsyncEncodePrefetcher worker.
+_PREFETCH_OK = "ok"
+_PREFETCH_EPOCH_END = "epoch_end"
+_PREFETCH_ERR = "err"
+_PREFETCH_STOPPED = "stopped"
+
+
+class AsyncEncodePrefetcher:
+    """Run dataloader fetch + VAE encode on a dedicated CUDA stream / Python thread.
+
+    Single persistent worker + bounded queue. Worker pulls a batch from the
+    dataloader, runs `encode_fn(batch)` on `stream`, and pushes the result.
+    Main thread pops via `get_next()` and `wait_stream` before consuming the
+    GPU tensors.
+
+    Epoch boundaries (StopIteration) are propagated as a sentinel payload so
+    the main thread can update its `epoch` / `batch_in_epoch` counters before
+    the next batch.
+    """
+
+    def __init__(self, dataloader, encode_fn, stream, device, prefetch_factor: int = 1):
+        self._dataloader = dataloader
+        self._encode_fn = encode_fn
+        self._stream = stream
+        self._device = device
+        self._q: "queue.Queue[tuple[str, object]]" = queue.Queue(maxsize=max(int(prefetch_factor), 1))
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("AsyncEncodePrefetcher already started")
+        self._thread = threading.Thread(target=self._worker_loop, daemon=True, name="encode-prefetch")
+        self._thread.start()
+
+    def _worker_loop(self) -> None:
+        try:
+            torch.cuda.set_device(self._device)
+            # Pin this thread to encode_stream for its lifetime so that EVERY
+            # GPU op originating here (including accelerate's automatic
+            # `send_to_device` inside `next(data_iter)` and the H2D copies
+            # inside `build_inputs`) lands on encode_stream rather than the
+            # default stream.
+            with torch.cuda.stream(self._stream):
+                data_iter = iter(self._dataloader)
+                while not self._stop_event.is_set():
+                    try:
+                        batch = next(data_iter)
+                    except StopIteration:
+                        if not self._put_interruptible((_PREFETCH_EPOCH_END, None)):
+                            break
+                        if self._stop_event.is_set():
+                            break
+                        data_iter = iter(self._dataloader)
+                        continue
+
+                    try:
+                        inputs = self._encode_fn(batch)
+                    except BaseException as exc:  # noqa: BLE001
+                        try:
+                            self._q.put((_PREFETCH_ERR, exc), timeout=1.0)
+                        except queue.Full:
+                            logger.exception("encode prefetcher worker died but queue is full")
+                        return
+
+                    if not self._put_interruptible((_PREFETCH_OK, inputs)):
+                        break
+        except BaseException as exc:  # noqa: BLE001 — re-raise on main
+            try:
+                self._q.put((_PREFETCH_ERR, exc), timeout=1.0)
+            except queue.Full:
+                logger.exception("encode prefetcher worker died but queue is full")
+        finally:
+            try:
+                self._q.put_nowait((_PREFETCH_STOPPED, None))
+            except queue.Full:
+                pass
+
+    def get_next(self) -> tuple[str, object]:
+        return self._q.get()
+
+    def _put_interruptible(self, item) -> bool:
+        while not self._stop_event.is_set():
+            try:
+                self._q.put(item, timeout=0.2)
+                return True
+            except queue.Full:
+                continue
+        return False
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is None:
+            return
+        deadline = time.monotonic() + 30.0
+        while self._thread.is_alive() and time.monotonic() < deadline:
+            try:
+                self._q.get(timeout=0.1)
+            except queue.Empty:
+                pass
+        self._thread.join(timeout=1.0)
+        if self._thread.is_alive():
+            logger.warning("encode prefetcher worker did not exit within timeout")
+        self._thread = None
 
 
 class Wan22Trainer:
@@ -61,7 +169,7 @@ class Wan22Trainer:
             mixed_precision=self.mixed_precision,
             step_scheduler_with_optimizer=False,
         )
-        
+
         logger.info(
             "Accelerate training: distributed_type=%s zero_stage=%s world_size=%d process_index=%d cfg_mixed_precision=%s accelerator_mixed_precision=%s grad_accum=%d grad_clip=%.4f",
             self.accelerator.distributed_type,
@@ -121,12 +229,98 @@ class Wan22Trainer:
             self.model, self.optimizer, self.train_loader, self.scheduler
         )
         self.optimizer.zero_grad(set_to_none=True)
+        self._maybe_compile_mot()
+        self._maybe_compile_vae()
         self.wandb_run = None
         self._init_wandb()
         self._resume_or_load_checkpoint()
 
         val_size = len(self.val_dataset) if self.val_dataset is not None else len(self.train_dataset)
         logger.info("Train/val dataset size: %d/%d", len(self.train_dataset), val_size)
+
+    def _maybe_compile_mot(self):
+        """torch.compile MoT sub-modules (self_attn / cross_attn / ffn) per layer.
+
+        Cfg keys:
+          - compile_mot: bool, default false
+          - compile_mot_mode: str, default "default"
+        """
+        if not bool(self.cfg.get("compile_mot", False)):
+            return
+        mode = str(self.cfg.get("compile_mot_mode", "default"))
+        unwrapped = self.accelerator.unwrap_model(self.model)
+        mot = getattr(unwrapped, "mot", None)
+        if mot is None or not hasattr(mot, "mixtures"):
+            logger.warning("compile_mot=true but model has no `.mot.mixtures`; skipping")
+            return
+        # Multiple blocks share one inner-frame code object (via dynamo
+        # external_utils.wrap_inline); default recompile_limit=8 → fallback to
+        # eager after 8. Bump to 64 to leave headroom for seq-axis specializations.
+        import torch._dynamo as _dynamo
+        prev_limit = _dynamo.config.recompile_limit
+        _dynamo.config.recompile_limit = max(prev_limit, 64)
+        compiled = 0
+        for expert in mot.mixtures.values():
+            for block in getattr(expert, "blocks", []):
+                for sub in ("self_attn", "cross_attn", "ffn"):
+                    mod = getattr(block, sub, None)
+                    if mod is None:
+                        continue
+                    mod.forward = torch.compile(mod.forward, mode=mode, dynamic=True)
+                    compiled += 1
+        logger.info(
+            "Compiled %d MoT sub-modules across %d experts (mode=%s, dynamic=True, recompile_limit %d→%d)",
+            compiled, len(mot.mixtures), mode, prev_limit, _dynamo.config.recompile_limit,
+        )
+
+    def _maybe_compile_vae(self):
+        """torch.compile vae.single_encode (no-grad path).
+
+        Cfg keys (hydra):
+          - compile_vae: bool, default false
+          - compile_vae_mode: str, default "default"
+              Pass "reduce-overhead" to use inductor + cudagraphs (lower kernel
+              launch overhead, but cudagraph re-captures whenever input shape
+              or tensor address changes).
+
+        VAE encode is not part of the trained graph (@torch.no_grad), so this
+        is a pure latency play.
+        """
+        if not bool(self.cfg.get("compile_vae", False)):
+            return
+        mode = str(self.cfg.get("compile_vae_mode", "default"))
+        unwrapped = self.accelerator.unwrap_model(self.model)
+        vae = getattr(unwrapped, "vae", None)
+        if vae is None or not hasattr(vae, "single_encode"):
+            logger.warning("compile_vae=true but model has no `.vae.single_encode`; skipping")
+            return
+        # `WanVideoVAE.scale` is a Python list of CPU tensors built in
+        # __init__ (`[self.mean, 1.0/self.std]`). Inside `model.encode` they
+        # are `.to(device=mu.device)`-d every call. Inductor + cudagraphs
+        # refuses to capture under reduce-overhead because of that CPU input
+        # ("skipping cudagraphs due to cpu device"). Move them to the
+        # accelerator device once so the per-call `.to(device=...)` becomes a
+        # same-device no-op and cudagraph capture proceeds.
+        device = self.accelerator.device
+        if hasattr(vae, "mean") and isinstance(vae.mean, torch.Tensor) and vae.mean.device != device:
+            vae.mean = vae.mean.to(device)
+        if hasattr(vae, "std") and isinstance(vae.std, torch.Tensor) and vae.std.device != device:
+            vae.std = vae.std.to(device)
+        if hasattr(vae, "scale") and isinstance(vae.scale, list):
+            vae.scale = [s.to(device) if isinstance(s, torch.Tensor) and s.device != device else s for s in vae.scale]
+        compiled_single_encode = torch.compile(vae.single_encode, mode=mode)
+        if mode == "reduce-overhead":
+            # `WanVideoVAE.encode(videos, ...)` calls `single_encode` once per
+            # video in the batch (bs=54 → 54 calls) and `torch.stack`s the
+            # outputs. Under cudagraph the output tensor aliases a single
+            # captured static buffer, so call N+1 clobbers the result of
+            # call N before the stack reads it. Clone to break the alias.
+            def _cloned_single_encode(*args, **kwargs):
+                return compiled_single_encode(*args, **kwargs).clone()
+            vae.single_encode = _cloned_single_encode
+        else:
+            vae.single_encode = compiled_single_encode
+        logger.info("Compiled vae.single_encode (mode=%s)", mode)
 
     def _init_wandb(self):
         if not self.wandb_enabled or not self.accelerator.is_main_process:
@@ -179,6 +373,8 @@ class Wan22Trainer:
             num_workers=self.num_workers,
             pin_memory=torch.cuda.is_available(),
             worker_init_fn=worker_init_fn,
+            prefetch_factor=int(self.cfg.get("dataloader_prefetch_factor", 2)) if self.num_workers > 0 else None,
+            persistent_workers=bool(self.cfg.get("dataloader_persistent_workers", False)) if self.num_workers > 0 else False,
         )
 
     def _assert_dataset_length_consistent(self, dataset, dataset_name: str):
@@ -656,22 +852,97 @@ class Wan22Trainer:
         self.run_start_step = self.global_step
         self.run_start_time = time.perf_counter()
 
+        # Encode/DiT overlap: optional async path that runs build_inputs (H2D
+        # copies + VAE encode) on a dedicated CUDA stream / Python thread, so
+        # the synchronous wait disappears behind DiT fwd/bwd of the previous
+        # step. See AsyncEncodePrefetcher above.
+        encode_overlap = bool(self.cfg.get("encode_overlap", False))
+        encode_stream: "torch.cuda.Stream | None" = None
+        prefetcher: "AsyncEncodePrefetcher | None" = None
+        unwrapped_model = self.accelerator.unwrap_model(self.model)
+        if encode_overlap:
+            encode_stream = torch.cuda.Stream(device=self.accelerator.device)
+            # Warmup: if compile_vae is on, trigger Dynamo tracing for VAE in
+            # the MAIN thread before spawning the worker. Otherwise the worker
+            # thread would do the first compile concurrently with main's MoT
+            # compile and risk a Dynamo speculation-log race.
+            if bool(self.cfg.get("compile_vae", False)):
+                try:
+                    warmup_batch = next(iter(self.train_loader))
+                except StopIteration:
+                    raise RuntimeError("train_loader is empty; cannot warmup encode for compile_vae")
+                logger.info("encode_overlap: warming up compile_vae in main thread (1 batch)...")
+                with torch.no_grad():
+                    _ = unwrapped_model.build_inputs(warmup_batch)
+                torch.cuda.synchronize()
+                del warmup_batch, _
+                logger.info("encode_overlap: compile_vae warmup done")
+            prefetcher = AsyncEncodePrefetcher(
+                dataloader=self.train_loader,
+                encode_fn=unwrapped_model.build_inputs,
+                stream=encode_stream,
+                device=self.accelerator.device,
+                prefetch_factor=int(self.cfg.get("encode_prefetch_factor", 1)),
+            )
+            prefetcher.start()
+            logger.info(
+                "encode_overlap=True (prefetch_factor=%d, encode_stream=%s)",
+                int(self.cfg.get("encode_prefetch_factor", 1)),
+                encode_stream,
+            )
+        else:
+            logger.info("encode_overlap=False (synchronous encode)")
+
         while self.global_step < self.max_steps:
-            try:
-                sample = next(data_iter)
+            _t_step_start = time.perf_counter()
+            inputs = None
+            sample = None
+            if encode_overlap:
+                # Pop one prepared batch from the worker. Sentinels:
+                #   "ok"        -> payload is encoded inputs dict
+                #   "epoch_end" -> dataloader exhausted; bump counters
+                #   "err"       -> re-raise worker exception
+                #   "stopped"   -> worker exited; treat as end-of-data
+                while True:
+                    status, payload = prefetcher.get_next()
+                    if status == _PREFETCH_OK:
+                        inputs = payload
+                        break
+                    if status == _PREFETCH_EPOCH_END:
+                        self.epoch += 1
+                        self.batch_in_epoch = 0
+                        self.train_sampler.clear_resume_batch_offset()
+                        continue
+                    if status == _PREFETCH_ERR:
+                        raise payload  # type: ignore[misc]
+                    # _PREFETCH_STOPPED
+                    inputs = None
+                    break
+                if inputs is None:
+                    break  # exit while-loop; worker stopped
                 self.batch_in_epoch += 1
-            except StopIteration:
-                self.epoch += 1
-                self.batch_in_epoch = 0
-                self.train_sampler.clear_resume_batch_offset()
-                data_iter = iter(self.train_loader)
-                continue
+                # Make subsequent default-stream ops wait for the
+                # encode_stream's queued work (vae.encode + H2D copies).
+                torch.cuda.current_stream().wait_stream(encode_stream)
+            else:
+                try:
+                    sample = next(data_iter)
+                    self.batch_in_epoch += 1
+                except StopIteration:
+                    self.epoch += 1
+                    self.batch_in_epoch = 0
+                    self.train_sampler.clear_resume_batch_offset()
+                    data_iter = iter(self.train_loader)
+                    continue
 
             with self.accelerator.accumulate(self.model):
                 train_model = self.model if hasattr(self.model, "training_loss") else self.accelerator.unwrap_model(self.model)
 
                 with self.accelerator.autocast():
-                    loss, loss_dict = train_model.training_loss(sample)
+                    if encode_overlap:
+                        loss, loss_dict = train_model.training_loss_from_inputs(inputs)
+                    else:
+                        loss, loss_dict = train_model.training_loss(sample)
                 self.accelerator.backward(loss)
 
                 if self.accelerator.sync_gradients:
@@ -706,10 +977,12 @@ class Wan22Trainer:
                         if global_loss_metrics:
                             detail_str = " ".join([f"{k}={v:.4f}" for k, v in sorted(global_loss_metrics.items())])
                             description += detail_str + " "
-                        description += "lr=%.2e speed=%.2f step/s, %.2f samples/s eta=%s" % (
+                        _step_dt = time.perf_counter() - _t_step_start
+                        description += "lr=%.2e speed=%.2f step/s, %.2f samples/s step_dt=%.3fs eta=%s" % (
                             current_lr,
                             steps_per_sec,
                             steps_per_sec * self.batch_size * self.accelerator.num_processes,
+                            _step_dt,
                             eta_str,
                         )
                         logger.info(description)
@@ -778,8 +1051,12 @@ class Wan22Trainer:
                                 ckpt_info["weights_path"],
                                 ckpt_info["state_path"],
                             )
+                        if prefetcher is not None:
+                            prefetcher.stop()
                         return
 
+        if prefetcher is not None:
+            prefetcher.stop()
         ckpt_info = self.save_checkpoint()
         if self.accelerator.is_main_process:
             logger.info(


### PR DESCRIPTION
RoboTwin: warmup, prompt caching, per-inference timing in deploy_policy.py
Libero: warmup, prompt caching, per-inference timing in eval_libero_single.py
Core: torch.compile + CUDA Graph for denoise/prefill steps in fastwam.py

Test Conditions & Results

  Hardware:
  - CPU: AMD EPYC
  
Test Cases:

  Following the "Inference with Released Checkpoints" section in the project README, we evaluated both released checkpoints with single-GPU configuration (MULTIRUN.num_gpus=1, MULTIRUN.max_tasks_per_gpu=1) to isolate per-call inference timing:
  
Baseline: torch.compile disabled, prompt re-encoded every call, no warmup.
Optimized: torch.compile + CUDA Graph for denoise loop, torch.compile (inductor) for prefill, prompt pre-encoded once, warmup at init.

  Results:

<img width="540" height="125" alt="image" src="https://github.com/user-attachments/assets/de1d8ac8-74c6-4654-9615-323559e4fb5e" />

