### PR TITLE
添加了libero-plus的推理脚本

### DIFF
--- a/experiments/libero/eval_libero_batch.py
+++ b/experiments/libero/eval_libero_batch.py
@@ -1,0 +1,474 @@
+"""Batched LIBERO-Plus evaluation worker.
+
+Unlike ``eval_libero_single.py`` (one process per task_id, model loaded every
+time), this worker loads the model ONCE and then rolls out a *chunk* of
+task_ids in the same process. This is what makes LIBERO-Plus tractable:
+Plus requires ``num_trials=1`` per task_id (each task_id is already an
+independent perturbation sample), so with 2402 spatial tasks the
+single-task launcher would pay the ~135s model-load tax 2402 times. Here
+we pay it once per worker instead.
+
+The original LIBERO evaluation path (``eval_libero_single.py`` +
+``run_libero_parallel_test.sh``) is intentionally left untouched. This file
+reuses the per-episode rollout core (``run_single_episode``) but wraps it
+with its own task loop, resume-skip logic, and two video knobs.
+
+Result files are written in the exact same contract as the single launcher
+so that ``summarize_results.py`` and the scheduler's completion detection
+work unchanged:
+
+    $OUTPUT_DIR/<suite>/gpu{worker_id}_task{task_id}_results.json
+
+The filename's ``gpu`` slot is occupied by ``worker_id`` (downstream only
+parses ``task_id`` from it), while the JSON body's ``gpu_id`` field carries
+the real CUDA device for log correlation.
+"""
+
+import glob
+import json
+import logging
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any
+
+import hydra
+import numpy as np
+import torch
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
+
+# try:
+#     import rootutils
+#     rootutils.setup_root(__file__, indicator=".python-version", pythonpath=True)
+# except ModuleNotFoundError:
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+# ``eval_libero_single`` does a bare ``from action_ensembler import ...`` which
+# relies on the script's own directory being on sys.path[0] (true when run as
+# ``python experiments/libero/eval_libero_single.py``, which is how the
+# scheduler launches it). Add it explicitly so this module is robust to being
+# imported or run via ``-m`` / ``-c`` too.
+_script_dir = str(Path(__file__).resolve().parent)
+if _script_dir not in sys.path:
+    sys.path.insert(0, _script_dir)
+
+# Reuse the per-episode rollout core and all helpers from the single launcher.
+from experiments.libero.eval_libero_single import (  # noqa: E402
+    NumpyEncoder,
+    _load_model_checkpoint,
+    _mixed_precision_to_model_dtype,
+    _resolve_dataset_stats_path,
+    _resolve_eval_device,
+    run_single_episode,
+)
+from experiments.libero.libero_utils import (  # noqa: E402
+    LIBERO_ENV_RESOLUTION,
+    get_libero_env,
+    save_prediction_video,
+    save_rollout_video,
+)
+from fastwam.datasets.lerobot.processors.fastwam_processor import FastWAMProcessor  # noqa: E402
+from fastwam.datasets.lerobot.utils.normalizer import load_dataset_stats_from_json  # noqa: E402
+from fastwam.utils.pytorch_utils import set_global_seed  # noqa: E402
+from libero.libero import benchmark  # noqa: E402
+
+# The custom resolvers (eval/max/split) are already registered by
+# ``eval_libero_single`` (imported above), which is always imported before this
+# point. Re-registering would raise, so we register defensively only if a
+# resolver is somehow missing.
+for _name, _fn in (("eval", eval), ("max", lambda x: max(x)), ("split", lambda s, idx: s.split("/")[int(idx)])):
+    try:
+        OmegaConf.register_new_resolver(_name, _fn)
+    except ValueError:
+        pass
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+
+def _read_chunk(chunk_file: Path) -> list[tuple[str, int]]:
+    """Read a chunk file (one ``suite,task_id`` per line) into a list of tuples."""
+    tasks: list[tuple[str, int]] = []
+    with open(chunk_file, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split(",")
+            if len(parts) < 2:
+                logging.warning("Skipping malformed chunk line: %s", line)
+                continue
+            tasks.append((parts[0].strip(), int(parts[1].strip())))
+    return tasks
+
+
+def _result_file_exists(output_dir: Path, suite: str, task_id: int) -> bool:
+    """A task is considered done if any ``gpu*_task{id}_results.json`` exists.
+
+    Mirrors the scheduler's completion detection in
+    ``run_libero_parallel_test.sh`` (``gpu*_task${task_id}_results.json`` glob),
+    so resume-skip and the scheduler stay consistent regardless of which
+    worker originally wrote the file.
+    """
+    pattern = str(output_dir / suite / f"gpu*_task{task_id}_results.json")
+    return len(glob.glob(pattern)) > 0
+
+
+def _run_single_task_batched(
+    task,
+    initial_states,
+    model: torch.nn.Module,
+    processor: FastWAMProcessor,
+    cfg: DictConfig,
+    video_dir: Path,
+    predicted_video_dir: Path,
+    *,
+    action_horizon: int,
+    input_w: int,
+    input_h: int,
+    model_device: str,
+    suite: str,
+    task_id: int,
+    worker_id: int,
+    real_gpu_id: int,
+    save_video: bool,
+    video_budget: "VideoBudget",
+) -> dict:
+    """Per-task rollout for the batch worker.
+
+    Structurally mirrors ``run_single_task`` from ``eval_libero_single.py`` but:
+      * drives ``run_single_episode`` (the untouched rollout core) directly,
+      * gates rollout/prediction video saving behind ``save_video`` and a
+        per-worker ``video_budget`` (so 2402 Plus tasks do not write 2402 mp4s),
+      * writes the result file in the single-launcher contract with
+        ``worker_id`` in the filename and ``real_gpu_id`` in the body.
+    """
+    env, task_description = get_libero_env(task, LIBERO_ENV_RESOLUTION, cfg.get("seed"))
+    visualize_future_video = bool(cfg.EVALUATION.get("visualize_future_video", False))
+    results: dict[str, Any] = {
+        "task_suite": suite,
+        "task_id": task_id,
+        "task_description": task_description,
+        "successes": 0,
+        "failure_episodes": [],
+        "success_episodes": [],
+    }
+    if visualize_future_video:
+        results["episode_future_video_psnr"] = []
+        results["future_video_psnr_mean"] = None
+
+    num_trials = int(cfg.EVALUATION.num_trials)
+    allow_save = save_video and video_budget.has_quota()
+    for trial_idx in range(num_trials):
+        success, replay_images, predicted_future_video_clips, episode_mean_psnr = run_single_episode(
+            env=env,
+            initial_state=initial_states[trial_idx],
+            task_description=task_description,
+            model=model,
+            processor=processor,
+            cfg=cfg,
+            episode_idx=trial_idx,
+            action_horizon=action_horizon,
+            input_w=input_w,
+            input_h=input_h,
+            model_device=model_device,
+        )
+        if success:
+            results["successes"] += 1
+            results["success_episodes"].append(trial_idx)
+        else:
+            results["failure_episodes"].append(trial_idx)
+        if visualize_future_video:
+            results["episode_future_video_psnr"].append(episode_mean_psnr)
+
+        if allow_save:
+            save_rollout_video(
+                video_dir,
+                replay_images,
+                f"task{task_id}_trial{trial_idx}",
+                success=success,
+                task_description=task_description,
+            )
+            if visualize_future_video and len(predicted_future_video_clips) > 0:
+                all_gt_frames = []
+                all_pred_frames = []
+                for clip in predicted_future_video_clips:
+                    all_gt_frames.extend(clip["gt_frames"])
+                    all_pred_frames.extend(clip["pred_frames"])
+                    save_prediction_video(
+                        predicted_video_dir,
+                        clip["gt_frames"],
+                        clip["pred_frames"],
+                        f"task{task_id}_trial{trial_idx}",
+                        clip["replan_idx"],
+                        success=success,
+                        task_description=task_description,
+                    )
+                save_prediction_video(
+                    predicted_video_dir,
+                    all_gt_frames,
+                    all_pred_frames,
+                    f"task{task_id}_trial{trial_idx}",
+                    "all",
+                    success=success,
+                    task_description=task_description,
+                )
+
+    if visualize_future_video:
+        valid_psnr = [x for x in results["episode_future_video_psnr"] if x is not None]
+        if len(valid_psnr) > 0:
+            results["future_video_psnr_mean"] = float(np.mean(valid_psnr))
+
+    results["total_episodes"] = num_trials
+    results["gpu_id"] = real_gpu_id
+    results["worker_id"] = worker_id
+    results["task_suite"] = suite
+    results["task_id"] = task_id
+    return results
+
+
+class VideoBudget:
+    """Caps how many tasks a worker will save rollout videos for.
+
+    ``SAVE_VIDEO`` is the global on/off; ``MAX_VIDEOS_PER_WORKER`` bounds the
+    total count so a 2402-task Plus run does not flood disk. Once the budget
+    is spent, ``has_quota()`` returns False and the worker keeps producing
+    result JSONs without mp4s.
+    """
+
+    def __init__(self, max_videos: int):
+        self._max = int(max_videos)
+        self._spent = 0
+
+    def has_quota(self) -> bool:
+        return self._spent < self._max
+
+    def consume(self, n: int = 1) -> None:
+        self._spent += n
+
+
+def _load_model_once(cfg: DictConfig):
+    """Model + processor + dataset stats, loaded exactly once per worker.
+
+    Lifted verbatim from ``eval_single_process`` so behavior matches the
+    single launcher byte-for-byte.
+    """
+    model_device = _resolve_eval_device(cfg)
+    model_dtype = _mixed_precision_to_model_dtype(cfg.get("mixed_precision", "bf16"))
+    model = instantiate(cfg.model, model_dtype=model_dtype, device=model_device)
+    _load_model_checkpoint(model, str(cfg.ckpt))
+    model = model.to(model_device).eval()
+
+    dataset_stats_path = _resolve_dataset_stats_path(cfg)
+    dataset_stats = load_dataset_stats_from_json(str(dataset_stats_path))
+    processor: FastWAMProcessor = instantiate(cfg.data.train.processor).eval()
+    processor.set_normalizer_from_stats(dataset_stats)
+    logging.info("Using dataset stats: %s", dataset_stats_path)
+
+    action_horizon_cfg = cfg.EVALUATION.get("action_horizon", None)
+    if action_horizon_cfg is None:
+        action_horizon = int(cfg.data.train.num_frames) - 1
+    else:
+        action_horizon = int(action_horizon_cfg)
+    if action_horizon <= 0:
+        raise ValueError(f"EVALUATION.action_horizon must be positive, got {action_horizon}")
+
+    video_size = cfg.data.train.get("video_size", [224, 224])
+    if len(video_size) != 2:
+        raise ValueError(f"data.train.video_size must be [H, W], got {video_size}")
+    input_h = int(video_size[0])
+    input_w = int(video_size[1])
+
+    return model, processor, action_horizon, input_w, input_h, model_device
+
+
+@hydra.main(version_base="1.3", config_path="../../configs", config_name="sim_libero.yaml")
+def eval_batch_process(cfg: DictConfig):
+    start_time = time.time()
+
+    if cfg.get("seed") is not None:
+        set_global_seed(int(cfg.seed), get_worker_init_fn=False)
+
+    if cfg.ckpt is None:
+        raise ValueError("cfg.ckpt must not be None.")
+
+    env_num = int(cfg.EVALUATION.get("env_num", 1))
+    if env_num != 1:
+        raise ValueError("Only env_num=1 is supported in eval_libero_batch.py.")
+
+    # Worker identity + its chunk of work.
+    chunk_file = Path(cfg.EVALUATION.chunk_file)
+    worker_id = int(cfg.EVALUATION.worker_id)
+    real_gpu_id = int(cfg.gpu_id)
+    if not chunk_file.exists():
+        raise FileNotFoundError(f"Worker chunk file not found: {chunk_file}")
+
+    save_video = bool(cfg.EVALUATION.get("save_video", False))
+    max_videos = int(cfg.EVALUATION.get("max_videos_per_worker", 50))
+
+    output_dir = Path(cfg.EVALUATION.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Resolve benchmark dict once; suites are looked up per task.
+    benchmark_dict = benchmark.get_benchmark_dict()
+
+    # Load model exactly once for the whole chunk.
+    logging.info(
+        "[worker %d] Loading model once for chunk %s (save_video=%s, max_videos=%d)",
+        worker_id,
+        chunk_file,
+        save_video,
+        max_videos,
+    )
+    model, processor, action_horizon, input_w, input_h, model_device = _load_model_once(cfg)
+    logging.info("[worker %d] Model loaded in %.1fs", worker_id, time.time() - start_time)
+
+    tasks = _read_chunk(chunk_file)
+    total = len(tasks)
+    logging.info("[worker %d] Chunk has %d tasks", worker_id, total)
+
+    video_budget = VideoBudget(max_videos)
+
+    # Group-by-suite lazily: benchmark suites are cheap to instantiate but we
+    # avoid re-creating the same suite object across tasks of that suite.
+    suite_cache: dict[str, Any] = {}
+    completed = 0
+    failed = 0
+    skipped = 0
+
+    for idx, (suite, task_id) in enumerate(tasks):
+        tag = f"[worker {worker_id}] [{idx + 1}/{total}] suite={suite} task_id={task_id}"
+
+        # Resume-skip: result already exists (possibly from a previous run).
+        if _result_file_exists(output_dir, suite, task_id):
+            skipped += 1
+            logging.info("%s SKIP (result already exists)", tag)
+            continue
+
+        if suite not in suite_cache:
+            suite_cache[suite] = benchmark_dict[suite]()
+        task_suite = suite_cache[suite]
+        try:
+            task = task_suite.get_task(task_id)
+            initial_states = task_suite.get_task_init_states(task_id)
+        except Exception as exc:  # benchmark lookup failure
+            failed += 1
+            logging.error("%s FAILED to fetch task/init_states: %s\n%s", tag, exc, traceback.format_exc())
+            continue
+
+        # Plus mandates num_trials=1; pad defensively in case a suite returns
+        # fewer init states (matches the single launcher's guard).
+        num_trials = int(cfg.EVALUATION.num_trials)
+        while len(initial_states) < num_trials:
+            initial_states.extend(initial_states[: (num_trials - len(initial_states))])
+
+        suite_out = output_dir / suite
+        suite_out.mkdir(parents=True, exist_ok=True)
+        video_dir = suite_out / "videos"
+        if save_video:
+            video_dir.mkdir(parents=True, exist_ok=True)
+        predicted_video_dir = suite_out / "predicted_videos"
+        if save_video and bool(cfg.EVALUATION.get("visualize_future_video", False)):
+            predicted_video_dir.mkdir(parents=True, exist_ok=True)
+
+        # Per-task temporary cfg override so reused helpers see this task's id.
+        with open_dict_if_needed(cfg):
+            cfg.EVALUATION.task_id = task_id
+            cfg.EVALUATION.task_suite_name = suite
+
+        task_start = time.time()
+        try:
+            results = _run_single_task_batched(
+                task=task,
+                initial_states=initial_states,
+                model=model,
+                processor=processor,
+                cfg=cfg,
+                video_dir=video_dir,
+                predicted_video_dir=predicted_video_dir,
+                action_horizon=action_horizon,
+                input_w=input_w,
+                input_h=input_h,
+                model_device=model_device,
+                suite=suite,
+                task_id=task_id,
+                worker_id=worker_id,
+                real_gpu_id=real_gpu_id,
+                save_video=save_video,
+                video_budget=video_budget,
+            )
+            results["duration"] = time.time() - task_start
+            output_file = suite_out / f"gpu{worker_id}_task{task_id}_results.json"
+            with open(output_file, "w", encoding="utf-8") as f:
+                json.dump(results, f, indent=4, cls=NumpyEncoder)
+            completed += 1
+            if save_video and video_budget.has_quota():
+                video_budget.consume()
+            logging.info(
+                "%s DONE successes=%d/%d duration=%.1fs (completed=%d failed=%d skipped=%d)",
+                tag,
+                results["successes"],
+                num_trials,
+                results["duration"],
+                completed,
+                failed,
+                skipped,
+            )
+        except Exception as exc:
+            failed += 1
+            # Skip-on-failure: do NOT write a result file, log and move on.
+            # On a re-run the task will be retried (no result file to skip).
+            logging.error("%s FAILED during rollout: %s\n%s", tag, exc, traceback.format_exc())
+            continue
+
+    total_duration = time.time() - start_time
+    logging.info(
+        "[worker %d] Chunk finished: completed=%d failed=%d skipped=%d total=%d elapsed=%.1fs",
+        worker_id,
+        completed,
+        failed,
+        skipped,
+        total,
+        total_duration,
+    )
+    print(
+        f"[worker {worker_id}] DONE: completed={completed} failed={failed} "
+        f"skipped={skipped} total={total} elapsed={total_duration:.1f}s"
+    )
+    return {
+        "worker_id": worker_id,
+        "completed": completed,
+        "failed": failed,
+        "skipped": skipped,
+        "total": total,
+        "elapsed": total_duration,
+    }
+
+
+class _OpenDictCtx:
+    def __init__(self, cfg: DictConfig):
+        self.cfg = cfg
+        self._was_struct = OmegaConf.is_struct(cfg) if hasattr(OmegaConf, "is_struct") else False
+
+    def __enter__(self):
+        # OmegaConf.set_struct(cfg, False) is the supported way to allow writes;
+        # struct mode is off by default for these configs, so this is a no-op
+        # in practice but guards against future configs flipping struct on.
+        OmegaConf.set_struct(self.cfg, False)
+        return self.cfg
+
+    def __exit__(self, exc_type, exc, tb):
+        OmegaConf.set_struct(self.cfg, self._was_struct)
+        return False
+
+
+def open_dict_if_needed(cfg: DictConfig):
+    """Context manager that allows mutating ``cfg`` (e.g. per-task task_id)."""
+    return _OpenDictCtx(cfg)
+
+
+if __name__ == "__main__":
+    eval_batch_process()

--- a/experiments/libero/run_libero_parallel_test.sh
+++ b/experiments/libero/run_libero_parallel_test.sh
@@ -335,7 +335,13 @@ run_libero_eval() {
         # When the task exits, write a status file so the scheduler can detect failures promptly.
         tmux select-pane -t $SESSION_NAME:$pane_info 2>/dev/null
         tmux send-keys -t $SESSION_NAME:$pane_info "clear" C-m 2>/dev/null
-        tmux send-keys -t $SESSION_NAME:$pane_info "source ~/.bashrc && cd $ROOT_DIR && export EXP_NAME=$EXP_NAME && \
+        # CONDA_ENV lets a user point panes at a different env (e.g. a cloned
+        # fastwam_plus) without editing this script. Defaults to "fastwam" so
+        # the original usage is unchanged.
+        CONDA_ENV="${CONDA_ENV:-fastwam}"
+        tmux send-keys -t $SESSION_NAME:$pane_info "source ~/.bashrc && conda activate $CONDA_ENV && cd $ROOT_DIR && export EXP_NAME=$EXP_NAME && \
+            ${USE_LIBERO_PLUS:+export PYTHONPATH=$ROOT_DIR/LIBERO-plus && export LIBERO_CONFIG_PATH=$HOME/.libero_plus && export MAGICK_HOME=\$CONDA_PREFIX && export LD_LIBRARY_PATH=\$CONDA_PREFIX/lib:\$LD_LIBRARY_PATH && }\
+            ${USE_LIBERO_MASTER:+export PYTHONPATH=$ROOT_DIR/LIBERO-master && export LIBERO_CONFIG_PATH=$HOME/.libero && }\
             STATUS_FILE='$status_file' LOG_FILE='$log_file' RESULT_FILE='$result_file' && \
             CUDA_VISIBLE_DEVICES=$gpu_id python experiments/libero/eval_libero_single.py \
             task=$CONFIG ckpt=$CKPT \

--- a/experiments/libero/run_libero_plus_batch.sh
+++ b/experiments/libero/run_libero_plus_batch.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+# LIBERO-Plus batched evaluation scheduler.
+#
+# Unlike run_libero_parallel_test.sh (one short-lived process per task_id,
+# model reloaded every time), this scheduler launches one LONG-LIVED worker
+# per (GPU, slot). Each worker loads the model ONCE and rolls out a static
+# chunk of task_ids (eval_libero_batch.py), so the ~135s model-load tax is
+# paid once per worker instead of once per task.
+#
+# This is what makes LIBERO-Plus tractable: 2402 spatial tasks with
+# num_trials=1 would otherwise reload the model 2402 times.
+#
+# The original LIBERO path (run_libero_parallel_test.sh + eval_libero_single.py)
+# is untouched. This script is Plus-only and is selected by run_libero_eval.sh
+# when MODE=plus.
+#
+# Resume: workers skip any task whose gpu*_task{task_id}_results.json already
+# exists, so re-running the same command after a crash/interrupt picks up where
+# it left off. No queue state is needed.
+#
+# Completion is detected by counting result files (same contract as the
+# single-task scheduler), so summarize_results.py works unchanged.
+
+run_libero_plus_batch() {
+    local task_list_file=$1
+    echo "[plus-batch] task_file: $task_list_file"
+
+    require_non_empty() {
+        local var_name="$1"
+        local var_val="${!var_name}"
+        if [ -z "$var_val" ]; then
+            echo "Error: required variable $var_name is not set"
+            exit 1
+        fi
+    }
+
+    # Basic configuration
+    ROOT_DIR=${ROOT_DIR:-"$(pwd)"}
+    export ROOT_DIR
+    RUN_ID=${RUN_ID:-"eval_$(date +%Y%m%d_%H%M%S)"}
+    export RUN_ID
+    # RESULTS_SUBDIR is injected by run_libero_eval.sh ("libero_plus" for plus,
+    # "libero" for master). Default to libero_plus when run standalone.
+    RESULTS_SUBDIR=${RESULTS_SUBDIR:-"libero_plus"}
+    OUTPUT_DIR=${OUTPUT_DIR:-"$ROOT_DIR/evaluate_results/$RESULTS_SUBDIR/$RUN_ID"}
+    export OUTPUT_DIR
+    EXP_NAME=${EXP_NAME:-""}
+    export EXP_NAME
+    SESSION_NAME="libero_plus_batch"
+
+    echo "[plus-batch] EXP_NAME: $EXP_NAME"
+    mkdir -p "$OUTPUT_DIR"
+    echo "[plus-batch] Results will be saved to: $OUTPUT_DIR"
+
+    # Copy task_list_file into OUTPUT_DIR
+    cp "$task_list_file" "$OUTPUT_DIR/"
+    task_list_file="$OUTPUT_DIR/$(basename $task_list_file)"
+    echo "[plus-batch] Task list file copied to: $task_list_file"
+
+    # GPU configuration (same parsing as run_libero_parallel_test.sh)
+    if [ -z "$CUDA_VISIBLE_DEVICES" ]; then
+        require_non_empty "NUM_GPUS"
+        AVAILABLE_GPUS=$(seq 0 $((NUM_GPUS-1)) | tr '\n' ',' | sed 's/,$//')
+    else
+        AVAILABLE_GPUS=$CUDA_VISIBLE_DEVICES
+        NUM_GPUS=$(echo $CUDA_VISIBLE_DEVICES | tr ',' '\n' | wc -l)
+    fi
+    export NUM_GPUS
+    IFS=',' read -r -a GPU_ARRAY <<< "$AVAILABLE_GPUS"
+    echo "[plus-batch] NUM_GPUS: $NUM_GPUS, AVAILABLE_GPUS: $AVAILABLE_GPUS"
+
+    require_non_empty "MAX_TASKS_PER_GPU"
+    require_non_empty "NUM_TRIALS"
+
+    # Workers per GPU (configurable). Total workers = NUM_GPUS * WORKERS_PER_GPU.
+    # Default to MAX_TASKS_PER_GPU so a 2-GPU / MAX_TASKS_PER_GPU=2 run spawns
+    # 4 long-lived workers and cuts model loads to 4 instead of thousands.
+    WORKERS_PER_GPU=${WORKERS_PER_GPU:-$MAX_TASKS_PER_GPU}
+    NUM_WORKERS=$((NUM_GPUS * WORKERS_PER_GPU))
+    echo "[plus-batch] WORKERS_PER_GPU: $WORKERS_PER_GPU -> total workers: $NUM_WORKERS"
+
+    # Video knobs (see eval_libero_batch.py). Plus default: no videos.
+    SAVE_VIDEO=${SAVE_VIDEO:-false}
+    MAX_VIDEOS_PER_WORKER=${MAX_VIDEOS_PER_WORKER:-50}
+    export SAVE_VIDEO MAX_VIDEOS_PER_WORKER
+
+    # tmux grid: one pane per worker + no spare panes.
+    TMUX_GRID_ROWS=${TMUX_GRID_ROWS:-1}
+    TMUX_GRID_COLS=${TMUX_GRID_COLS:-$((NUM_WORKERS + 1))}
+    GRID_ROWS=$TMUX_GRID_ROWS
+    GRID_COLS=$TMUX_GRID_COLS
+    MAX_PANES=$((GRID_ROWS * GRID_COLS - 1))
+    if [ "$MAX_PANES" -lt "$NUM_WORKERS" ]; then
+        echo "Error: tmux grid too small (MAX_PANES=$MAX_PANES < NUM_WORKERS=$NUM_WORKERS). Increase TMUX_GRID_COLS/TMUX_GRID_ROWS."
+        exit 1
+    fi
+
+    TASK_LOG_DIR="$OUTPUT_DIR/task_logs"
+    CHUNK_DIR="$OUTPUT_DIR/chunks"
+    mkdir -p "$TASK_LOG_DIR" "$CHUNK_DIR"
+
+    # Checkpoint and config (same normalization as the single-task scheduler)
+    CKPT=${CKPT:-""}
+    export CKPT
+    CONFIG=${CONFIG:-""}
+    require_non_empty "CKPT"
+    require_non_empty "CONFIG"
+    CONFIG="${CONFIG#configs/}"
+    CONFIG="${CONFIG#task/}"
+    CONFIG="${CONFIG%.yaml}"
+    export CONFIG
+
+    echo "[plus-batch] CKPT: $CKPT"
+    echo "[plus-batch] CONFIG: $CONFIG"
+    echo "[plus-batch] NUM_TRIALS: $NUM_TRIALS"
+    echo "[plus-batch] SAVE_VIDEO: $SAVE_VIDEO  MAX_VIDEOS_PER_WORKER: $MAX_VIDEOS_PER_WORKER"
+
+    local total_tasks=$(wc -l < "$task_list_file")
+    echo "[plus-batch] Total tasks: $total_tasks"
+
+    # ---- Static chunking: split task_list into NUM_WORKERS chunks ----
+    # Each worker gets a contiguous slice. Remainder distributed to the first
+    # few workers so every task is assigned exactly once.
+    local base=$((total_tasks / NUM_WORKERS))
+    local rem=$((total_tasks % NUM_WORKERS))
+    local chunk_files=()
+    local start=1
+    local wid=0
+    while [ $wid -lt $NUM_WORKERS ]; do
+        local size=$base
+        if [ $wid -lt $rem ]; then
+            size=$((size + 1))
+        fi
+        local chunk_file="$CHUNK_DIR/chunk_worker${wid}.txt"
+        if [ $size -gt 0 ]; then
+            sed -n "${start},$((start + size - 1))p" "$task_list_file" > "$chunk_file"
+        else
+            : > "$chunk_file"
+        fi
+        chunk_files+=("$chunk_file")
+        echo "[plus-batch] worker $wid -> $size tasks ($chunk_file)"
+        start=$((start + size))
+        wid=$((wid + 1))
+    done
+
+    # ---- tmux session ----
+    if tmux has-session -t $SESSION_NAME 2>/dev/null; then
+        tmux kill-session -t $SESSION_NAME
+        echo "[plus-batch] Deleted existing session '$SESSION_NAME'"
+    fi
+    tmux new-session -d -s $SESSION_NAME
+
+    create_grid_layout() {
+        local window=$1
+        if [ $window -gt 0 ]; then
+            if ! tmux list-windows -t $SESSION_NAME | grep -q "^$window:"; then
+                tmux new-window -t $SESSION_NAME:$window
+            fi
+        fi
+        local pane_count=$(tmux list-panes -t $SESSION_NAME:$window | wc -l)
+        for ((i=pane_count; i<GRID_ROWS*GRID_COLS-1; i++)); do
+            tmux split-window -t $SESSION_NAME:$window
+            tmux select-layout -t $SESSION_NAME:$window tiled
+        done
+    }
+    create_grid_layout 0
+
+    ensure_pane_exists() {
+        local window_id=$1
+        local pane_id=$2
+        if [ $window_id -gt 0 ]; then
+            if ! tmux list-windows -t $SESSION_NAME | grep -q "^$window_id:" 2>/dev/null; then
+                tmux new-window -t $SESSION_NAME:$window_id 2>/dev/null
+                create_grid_layout $window_id
+            fi
+        fi
+        if [ $pane_id -eq 0 ] && [ $window_id -gt 0 ]; then
+            create_grid_layout $window_id
+        fi
+    }
+
+    # ---- Launch one long-lived worker per pane ----
+    echo "[plus-batch] Launching $NUM_WORKERS workers..."
+    local next_pane=0
+    for wid in "${!chunk_files[@]}"; do
+        local chunk_file="${chunk_files[$wid]}"
+        # Map worker index -> (real GPU id, slot). Round-robin GPUs so workers
+        # spread across cards; within a GPU, slots 0..WORKERS_PER_GPU-1.
+        local gpu_idx=$((wid % NUM_GPUS))
+        local real_gpu_id=${GPU_ARRAY[$gpu_idx]}
+
+        local window_id=$((next_pane / MAX_PANES))
+        local pane_id=$((next_pane % MAX_PANES))
+        local pane_info="$window_id.$pane_id"
+        ensure_pane_exists $window_id $pane_id
+        next_pane=$((next_pane + 1))
+
+        local log_file="$TASK_LOG_DIR/worker${wid}_gpu${real_gpu_id}.log"
+        echo "[plus-batch] Launching worker $wid on GPU$real_gpu_id (pane $pane_info), chunk=$chunk_file, log=$log_file"
+
+        tmux select-pane -t $SESSION_NAME:$pane_info 2>/dev/null
+        tmux send-keys -t $SESSION_NAME:$pane_info "clear" C-m 2>/dev/null
+        # CONDA_ENV lets a user point panes at a different env (e.g. a cloned
+        # fastwam_plus) without editing this script. Defaults to "fastwam" so
+        # the original usage is unchanged.
+        CONDA_ENV="${CONDA_ENV:-fastwam}"
+        tmux send-keys -t $SESSION_NAME:$pane_info "source ~/.bashrc && conda activate $CONDA_ENV && cd $ROOT_DIR && \
+            LOG_FILE='$log_file' && export EXP_NAME=$EXP_NAME && \
+            export PYTHONPATH=$ROOT_DIR/LIBERO-plus && \
+            export LIBERO_CONFIG_PATH=$HOME/.libero_plus && \
+            export MAGICK_HOME=\$CONDA_PREFIX && \
+            export LD_LIBRARY_PATH=\$CONDA_PREFIX/lib:\$LD_LIBRARY_PATH && \
+            CUDA_VISIBLE_DEVICES=$real_gpu_id python experiments/libero/eval_libero_batch.py \
+            task=$CONFIG ckpt=$CKPT \
+            EVALUATION.num_trials=$NUM_TRIALS \
+            EVALUATION.output_dir=$OUTPUT_DIR \
+            +EVALUATION.chunk_file=$chunk_file \
+            +EVALUATION.worker_id=$wid \
+            +EVALUATION.save_video=$SAVE_VIDEO \
+            +EVALUATION.max_videos_per_worker=$MAX_VIDEOS_PER_WORKER \
+            gpu_id=$real_gpu_id $EXTRA_ARGS > \"\$LOG_FILE\" 2>&1; \
+            echo \"[worker $wid] exited rc=\$?\"" C-m 2>/dev/null
+        sleep 0.5
+    done
+
+    # ---- Wait for completion by counting result files ----
+    # Same contract as run_libero_parallel_test.sh: a task is done when its
+    # gpu*_task{task_id}_results.json exists. We count across all suites.
+    local monitoring_interval=${MONITORING_INTERVAL:-15}
+    local status_interval=${STATUS_INTERVAL:-60}
+    local last_status_time=0
+
+    echo "[plus-batch] Workers launched. Waiting for completion (total=$total_tasks)..."
+    while true; do
+        current_time=$(date +%s)
+        local total_completed=$(find "$OUTPUT_DIR" -type f -name "gpu*_task*_results.json" | wc -l)
+        if [ "$total_completed" -ge "$total_tasks" ]; then
+            echo "[plus-batch] All $total_tasks tasks complete!"
+            break
+        fi
+
+        # Detect total worker death (all panes exited) while tasks remain:
+        # if no eval_libero_batch.py process is alive and we are still short,
+        # something went wrong -- report and stop to avoid an infinite loop.
+        local alive_workers=$(pgrep -fc "eval_libero_batch.py" 2>/dev/null || echo 0)
+        if [ "$alive_workers" -eq 0 ] && [ "$total_completed" -lt "$total_tasks" ]; then
+            echo "[plus-batch] WARNING: no live workers but $total_completed/$total_tasks done."
+            echo "[plus-batch] Some workers crashed. Re-run this command to resume unfinished tasks (already-done ones are skipped)."
+            echo "[plus-batch] Incomplete? Check $TASK_LOG_DIR and re-run."
+            break
+        fi
+
+        if [ $((current_time - last_status_time)) -ge $status_interval ]; then
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] === Plus-batch Status ==="
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] Completed: $total_completed / $total_tasks"
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] Live workers: $alive_workers / $NUM_WORKERS"
+            for wid in "${!chunk_files[@]}"; do
+                local cdone=$(find "$OUTPUT_DIR" -type f -name "gpu${wid}_task*_results.json" | wc -l)
+                local csize=$(wc -l < "${chunk_files[$wid]}")
+                echo "[$(date '+%Y-%m-%d %H:%M:%S')]   worker $wid: $cdone / $csize done"
+            done
+            echo "[$(date '+%Y-%m-%d %H:%M:%S']) =================="
+            last_status_time=$current_time
+        fi
+
+        sleep $monitoring_interval
+    done
+
+    # ---- Summarize ----
+    echo "[plus-batch] Generating evaluation report..."
+    python experiments/libero/summarize_results.py --output_dir="$OUTPUT_DIR"
+    echo "[plus-batch] Done. Results: $OUTPUT_DIR"
+}
+
+
+# Entrypoint
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    if [ $# -lt 1 ]; then
+        echo "Error: task file path is required"
+        echo "Usage: $0 <task_file>"
+        exit 1
+    fi
+    test_file="$1"
+    run_libero_plus_batch "$test_file"
+    exit $?
+fi

--- a/run_libero_eval.sh
+++ b/run_libero_eval.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# FastWAM LIBERO / LIBERO-Plus 推理一键脚本
+#
+# 用法：先 conda activate fastwam && cd 到项目根目录，再
+#   bash run_libero_eval.sh
+#
+# 只改下面【参数块】即可，无需每次手打一堆 export。
+# MODE="plus"   → LIBERO-Plus 鲁棒性推理（NUM_TRIALS 默认 1，注入 plus 环境变量，走批量调度）
+# MODE="master" → 原版 LIBERO 推理  （NUM_TRIALS 默认 50，注入 master 环境变量，走原版单任务调度）
+#
+# 结果按 MODE 自动分流到子目录：
+#   plus  → evaluate_results/libero_plus/$RUN_ID/
+#   master→ evaluate_results/libero/$RUN_ID/
+
+# ==================== 参数块（按需修改）====================
+MODE="plus"                                       # "plus" | "master"
+GPUS="2"                                          # 用哪些卡，逗号分隔，如 "0,1,2"
+TASK_LIST="task_lists/libero_spatial.txt"         # 评测任务清单
+                                                  #   plus : task_lists/libero_<suite>.txt
+                                                  #   master: task_lists/master_all.txt 或 master_<suite>.txt
+
+# checkpoint 二选一：
+#   release: checkpoints/fastwam_release/libero_uncond_2cam224.pt
+#   自训  : 你的训练输出路径/xxx.pt
+CKPT="checkpoints/fastwam_release/libero_uncond_2cam224.pt"
+
+# dataset_stats：
+#   release 版 stats 文件名带前缀，必须显式指定
+#   自训 ckpt 若同目录有 dataset_stats.json，可留空 ""
+STATS="checkpoints/fastwam_release/libero_uncond_2cam224_dataset_stats.json"
+
+# —— 以下一般不用改 ——
+CONFIG="libero_uncond_2cam224_1e-4"               # configs/task/ 下的配置名（不带 .yaml）
+MAX_TASKS_PER_GPU=2                               # 每卡并发任务数（80G 卡跑 2 个够用）
+NUM_TRIALS=""                                     # 留空：plus→1 / master→50；填数字则强制覆盖
+
+# 用哪个 conda env 跑 worker。下游调度脚本的 tmux pane 会 `conda activate $CONDA_ENV`。
+# 默认 fastwam（与原版一致）；若建了独立 env（见 LIBERO_PLUS_SETUP_LOG.md 第十节），
+# 改成你的 env 名，或在 shell 里 `export CONDA_ENV=fastwam_plus` 覆盖。
+CONDA_ENV="liberoplus"
+
+# —— 仅 plus 批量模式相关 ——
+WORKERS_PER_GPU=""                                # 留空：默认 = MAX_TASKS_PER_GPU；填数字则每卡常驻 worker 数
+SAVE_VIDEO="false"                                # plus 是否保存 rollout 视频（false 只留 json）
+MAX_VIDEOS_PER_WORKER="50"                        # 每个 worker 最多保存多少个 task 的视频（防止磁盘爆炸）
+# ==========================================================
+
+set -euo pipefail
+
+# 根据 MODE 决定环境变量开关、默认 NUM_TRIALS、结果子目录、调度脚本
+if [[ "${MODE}" == "plus" ]]; then
+  NUM_TRIALS="${NUM_TRIALS:-1}"
+  RESULTS_SUBDIR="libero_plus"
+  export USE_LIBERO_PLUS=1
+elif [[ "${MODE}" == "master" ]]; then
+  NUM_TRIALS="${NUM_TRIALS:-50}"
+  RESULTS_SUBDIR="libero"
+  export USE_LIBERO_MASTER=1
+else
+  echo "Error: MODE 必须是 'plus' 或 'master'，当前: '${MODE}'" >&2
+  exit 1
+fi
+
+# 文件存在性校验（早失败早提示，免得跑到一半才发现路径错）
+[[ -f "${TASK_LIST}" ]] || { echo "Error: TASK_LIST 不存在: ${TASK_LIST}" >&2; exit 1; }
+[[ -f "${CKPT}"       ]] || { echo "Error: CKPT 不存在: ${CKPT}" >&2; exit 1; }
+if [[ -n "${STATS}" ]]; then
+  [[ -f "${STATS}" ]] || { echo "Error: STATS 不存在: ${STATS}" >&2; exit 1; }
+fi
+
+export CONFIG
+export CUDA_VISIBLE_DEVICES="${GPUS}"
+export MAX_TASKS_PER_GPU
+export NUM_TRIALS
+export CKPT
+export RESULTS_SUBDIR
+export CONDA_ENV
+# 生成 RUN_ID；两个调度脚本都读它（都有默认值，但显式统一便于日志对应）
+export RUN_ID="${RUN_ID:-eval_$(date +%Y%m%d_%H%M%S)}"
+export ROOT_DIR="${ROOT_DIR:-$(pwd)}"
+# 用 OUTPUT_DIR 环境变量覆盖调度脚本的默认值，确保按 MODE 分流到子目录
+export OUTPUT_DIR="${ROOT_DIR}/evaluate_results/${RESULTS_SUBDIR}/${RUN_ID}"
+
+if [[ -n "${STATS}" ]]; then
+  export EXTRA_ARGS="EVALUATION.dataset_stats_path=${STATS}"
+else
+  export EXTRA_ARGS=""
+fi
+
+# plus 批量模式的视频/worker 旋钮（master 调度脚本不读这些，export 无害）
+export SAVE_VIDEO
+export MAX_VIDEOS_PER_WORKER
+# WORKERS_PER_GPU 留空时让调度脚本自取默认（=MAX_TASKS_PER_GPU）
+[[ -n "${WORKERS_PER_GPU}" ]] && export WORKERS_PER_GPU || true
+
+echo "==================== LIBERO 推理 ===================="
+echo "  MODE          : ${MODE}"
+echo "  GPUS          : ${GPUS}"
+echo "  TASK_LIST     : ${TASK_LIST} ($(wc -l < "${TASK_LIST}") 任务)"
+echo "  NUM_TRIALS    : ${NUM_TRIALS}"
+echo "  MAX_TASKS_PER_GPU: ${MAX_TASKS_PER_GPU}"
+echo "  CKPT          : ${CKPT}"
+echo "  STATS         : ${STATS:-<自动查找>}"
+echo "  CONFIG        : ${CONFIG}"
+echo "  CONDA_ENV     : ${CONDA_ENV}"
+echo "  RESULTS_SUBDIR: ${RESULTS_SUBDIR}"
+echo "  OUTPUT_DIR    : ${OUTPUT_DIR}"
+if [[ "${MODE}" == "plus" ]]; then
+  echo "  WORKERS_PER_GPU: ${WORKERS_PER_GPU:-<默认=MAX_TASKS_PER_GPU>}"
+  echo "  SAVE_VIDEO    : ${SAVE_VIDEO}"
+  echo "  MAX_VIDEOS_PER_WORKER: ${MAX_VIDEOS_PER_WORKER}"
+fi
+echo "====================================================="
+
+if [[ "${MODE}" == "plus" ]]; then
+  bash experiments/libero/run_libero_plus_batch.sh "${TASK_LIST}"
+else
+  bash experiments/libero/run_libero_parallel_test.sh "${TASK_LIST}"
+fi


### PR DESCRIPTION
由于原本的FastWAM项目中并未使用LIBERO-Plus进行推理，如果直接复用LIBERO的推理脚本的话会出现每完成一个task就会load一次模型得到问题，超级浪费时间，其根本原因在于LIBERO的task数量少且num_trials=50，load模型的时间成本不是很多，而LIBERO-Plus则有10030个task（4个suite）而且每个任务只进行一次trial，即完整的推理过程中需要load10030次模型，消耗时间非常非常非常的长。
这里将推理的逻辑改成了让一个进程来跑多个task，worker 启动加载模型一次，循环跑一批 task_id，每个 task 内部仍 num_trials=1，跑完一个写一个结果文件，全部跑完才退出。可以节约load模型的时间，将load模型的次数调整为了总worker数。
具体进行推理的时候只需要调整run_libero_eval.sh的参数如指定GPU，taskname等，然后直接bash即可
而对于原版的LIBERO的推理实际上也可以直接复用推理LIBERO-Plus环境，只需要修改run_libero_eval.sh的MODE="plus"参数即可，不过由于我的路径下的LIBERO库的命名是“LIBERO-master”而不是“LIBERO”，可能实际上推理LIBERO的时候会出一些问题，可能需要修改一下配置文件中的地址之类的()